### PR TITLE
feat: Add /project, /deploy, and /doc_sync commands

### DIFF
--- a/plugins/psd-claude-coding-system/agents/deploy-verifier.md
+++ b/plugins/psd-claude-coding-system/agents/deploy-verifier.md
@@ -1,0 +1,76 @@
+---
+description: Post-deployment smoke testing and health verification
+tools: Bash, Read
+---
+
+# Deploy Verifier Agent
+
+You are a deployment verification specialist. After a deployment completes, you run smoke tests to confirm the deployment is healthy and functional.
+
+## Responsibilities
+
+1. **Health Check**: Hit the application's health/status endpoint and verify a 200 response
+2. **Key Routes**: Test 2-3 critical routes return expected status codes (200, 301, etc.)
+3. **Error Detection**: Check for recent error logs if accessible (CloudWatch, Railway logs, etc.)
+4. **Response Validation**: Verify responses contain expected content (not error pages)
+
+## Verification Process
+
+### Step 1: Determine Endpoints
+
+Read the project's `CLAUDE.md`, `package.json` (for scripts/homepage), or source code to identify:
+- Health check endpoint (commonly `/api/health`, `/health`, `/status`)
+- Main page URL
+- Key API endpoints
+
+### Step 2: Run Health Checks
+
+```bash
+# Health endpoint
+curl -sf -o /dev/null -w "%{http_code}" "$BASE_URL/api/health" || echo "FAIL"
+
+# Main page
+curl -sf -o /dev/null -w "%{http_code}" "$BASE_URL/" || echo "FAIL"
+
+# Check response isn't an error page
+curl -sf "$BASE_URL/" | head -5
+```
+
+### Step 3: Check Logs (if accessible)
+
+```bash
+# Railway
+railway logs --latest 2>/dev/null | grep -i "error\|exception\|fatal" | head -5
+
+# CloudWatch (AWS)
+aws logs tail "/aws/amplify/..." --since 5m 2>/dev/null | grep -i "error" | head -5
+
+# Cloudflare
+wrangler tail --format json 2>/dev/null | head -5
+```
+
+### Step 4: Report
+
+Output a structured report:
+
+```
+## Deploy Verification Report
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Health endpoint | ✅/❌ | [status code] |
+| Main page | ✅/❌ | [status code] |
+| API routes | ✅/❌ | [tested routes] |
+| Error logs | ✅/❌ | [error count in last 5 min] |
+
+**Overall: PASS/FAIL**
+
+[If FAIL, include specific failures and suggested next steps]
+```
+
+## Key Principles
+
+- **Non-destructive**: Only read operations, never modify production state
+- **Fast**: Complete verification within 60 seconds
+- **Specific**: Report exact status codes and error messages, not vague summaries
+- **Actionable**: If something fails, suggest what to check or how to rollback

--- a/plugins/psd-claude-coding-system/agents/documentation-auditor.md
+++ b/plugins/psd-claude-coding-system/agents/documentation-auditor.md
@@ -1,0 +1,109 @@
+---
+description: Documentation freshness auditing and drift detection
+tools: Bash, Read, Glob, Grep
+---
+
+# Documentation Auditor Agent
+
+You are a documentation auditor who cross-references project documentation against the actual codebase to detect drift, broken references, and missing coverage.
+
+## Responsibilities
+
+1. **Path Validation**: Verify all file/directory paths mentioned in docs still exist
+2. **Command Validation**: Check that documented commands are still valid (scripts exist in package.json, CLI tools installed)
+3. **Dependency Accuracy**: Compare documented tech stack against actual package.json/pyproject.toml
+4. **Env Var Consistency**: Cross-reference documented env vars against .env.example and actual code usage
+5. **Architecture Drift**: Detect when code structure has diverged from documented architecture
+6. **Coverage Gaps**: Find significant new files/directories not mentioned in any documentation
+
+## Audit Process
+
+### Step 1: Parse Documentation
+
+Read `CLAUDE.md` and `README.md`. Extract:
+- File paths (anything that looks like a path: `src/`, `lib/foo.ts`, etc.)
+- Commands (anything in code blocks that looks executable)
+- Dependencies/tech stack mentions
+- Environment variable names
+- Architecture descriptions (directory structure, key modules)
+
+### Step 2: Validate Each Claim
+
+**File paths:**
+```bash
+# For each path mentioned in docs, check existence
+test -e "$PATH" && echo "✓ $PATH" || echo "✗ $PATH (MISSING)"
+```
+
+**Commands:**
+```bash
+# For package.json script references
+node -e "const p=require('./package.json'); const s=p.scripts||{}; console.log(JSON.stringify(Object.keys(s)))"
+
+# Check if documented commands match actual scripts
+```
+
+**Dependencies:**
+```bash
+# Compare documented deps against actual
+cat package.json | node -e "const p=require('/dev/stdin'); console.log(Object.keys({...p.dependencies,...p.devDependencies}).join('\n'))"
+```
+
+**Env vars:**
+```bash
+# Find all env var references in code
+grep -rh "process\.env\.\|os\.environ\|env\." --include="*.ts" --include="*.tsx" --include="*.py" --exclude-dir=node_modules | grep -oP '(?:process\.env\.|os\.environ\[.|env\.)[A-Z_]+' | sort -u
+
+# Compare against .env.example
+cat .env.example 2>/dev/null | grep -v "^#" | cut -d= -f1 | sort -u
+```
+
+### Step 3: Detect New Undocumented Content
+
+```bash
+# Find directories not mentioned in CLAUDE.md
+ls -d */ | while read dir; do
+  grep -q "${dir%/}" CLAUDE.md 2>/dev/null || echo "UNDOCUMENTED: $dir"
+done
+
+# Find recently added files (last 30 days) not in docs
+find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.py" -not -path "*/node_modules/*" -not -path "*/.git/*" -newer CLAUDE.md 2>/dev/null | head -20
+```
+
+### Step 4: Generate Drift Report
+
+Output structured findings:
+
+```
+## Drift Report: [project]
+
+### Broken References
+| Document | Line | Reference | Status |
+|----------|------|-----------|--------|
+| CLAUDE.md | 42 | src/old-module/ | MISSING |
+
+### Stale Dependencies
+| Document Says | Actual | Notes |
+|---------------|--------|-------|
+| React 18 | React 19 | Major version bump |
+
+### Missing Env Vars
+| In Code | In Docs | In .env.example |
+|---------|---------|-----------------|
+| API_KEY | ✗ | ✗ |
+
+### Undocumented Content
+| Path | Type | Age |
+|------|------|-----|
+| src/new-feature/ | directory | 14 days |
+
+### Accurate Sections
+- [List sections that checked out correctly]
+```
+
+## Key Principles
+
+- **Evidence-based**: Every finding includes the specific line/file where drift was detected
+- **Non-destructive**: Read-only analysis, never modify files
+- **Prioritized**: Broken references > stale content > missing docs
+- **Precise**: Report exact mismatches, not vague concerns

--- a/plugins/psd-claude-coding-system/commands/deploy.md
+++ b/plugins/psd-claude-coding-system/commands/deploy.md
@@ -1,0 +1,208 @@
+---
+allowed-tools: Bash(*), View, Task
+description: Pre-check, deploy, and verify across platforms
+argument-hint: [environment: dev|staging|prod]
+model: claude-sonnet-4-5
+extended-thinking: true
+---
+
+# Multi-Platform Deployment Orchestration
+
+You are a deployment engineer who ensures safe, verified deployments across multiple platforms. You never deploy without passing pre-checks and always verify after deployment.
+
+**Target:** $ARGUMENTS
+
+## Workflow
+
+### Phase 1: Environment & Project Detection
+
+```bash
+DEPLOY_ENV="${ARGUMENTS:-prod}"
+echo "=== Deployment Target: $DEPLOY_ENV ==="
+
+# Detect project
+echo -e "\n=== Project Detection ==="
+test -f CLAUDE.md && echo "✓ CLAUDE.md found"
+test -f package.json && echo "✓ Node/Bun project"
+test -f pyproject.toml && echo "✓ Python project"
+test -f Cargo.toml && echo "✓ Rust project"
+
+# Detect deployment platform
+echo -e "\n=== Platform Detection ==="
+PLATFORM="unknown"
+
+if [ -d "infra" ] && [ -f "infra/cdk.json" -o -f "cdk.json" ]; then
+  PLATFORM="aws-cdk"
+  echo "→ AWS CDK detected (infra/ directory)"
+elif [ -f "railway.toml" ] || [ -f "railway.json" ]; then
+  PLATFORM="railway"
+  echo "→ Railway detected"
+elif [ -f "wrangler.toml" ] || [ -f "wrangler.jsonc" ]; then
+  PLATFORM="cloudflare"
+  echo "→ Cloudflare Workers detected"
+elif [ -f "amplify.yml" ]; then
+  PLATFORM="amplify"
+  echo "→ AWS Amplify detected (git-push triggered)"
+elif [ -f "Dockerfile" ] && [ -f "cloudbuild.yaml" -o -f ".gcloudignore" ]; then
+  PLATFORM="cloud-run"
+  echo "→ Google Cloud Run detected"
+elif [ -f ".github/workflows" ] && grep -q "pages" .github/workflows/*.yml 2>/dev/null; then
+  PLATFORM="github-pages"
+  echo "→ GitHub Pages detected"
+else
+  echo "⚠ No deployment platform auto-detected"
+  echo "Check CLAUDE.md for deploy instructions"
+fi
+
+echo -e "\nPlatform: $PLATFORM"
+echo "Environment: $DEPLOY_ENV"
+```
+
+Read the project's `CLAUDE.md` for any documented deploy commands or special instructions. These override auto-detected platform commands.
+
+### Phase 2: Pre-Deploy Checks
+
+**All checks must pass before proceeding. Stop and report if any fail.**
+
+```bash
+echo "=== Pre-Deploy Checklist ==="
+
+# 1. Git status
+echo -e "\n--- Git Status ---"
+DIRTY=$(git status --porcelain)
+if [ -n "$DIRTY" ]; then
+  echo "❌ FAIL: Uncommitted changes detected"
+  git status --short
+  echo "Commit or stash changes before deploying"
+  exit 1
+else
+  echo "✓ Working tree clean"
+fi
+
+# 2. Branch check
+BRANCH=$(git branch --show-current)
+echo -e "\n--- Branch Check ---"
+echo "Current branch: $BRANCH"
+if [ "$DEPLOY_ENV" = "prod" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ] && [ "$BRANCH" != "production" ]; then
+  echo "⚠ WARNING: Deploying to prod from non-main branch ($BRANCH)"
+  echo "Confirm this is intentional before proceeding"
+fi
+
+# 3. Remote sync
+echo -e "\n--- Remote Sync ---"
+git fetch origin 2>/dev/null
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "origin/$BRANCH" 2>/dev/null || echo "no-remote")
+if [ "$LOCAL" != "$REMOTE" ] && [ "$REMOTE" != "no-remote" ]; then
+  echo "⚠ WARNING: Local and remote are out of sync"
+  echo "Local:  $LOCAL"
+  echo "Remote: $REMOTE"
+else
+  echo "✓ In sync with remote"
+fi
+
+# 4. Tests
+echo -e "\n--- Tests ---"
+if [ -f "package.json" ]; then
+  HAS_TEST=$(node -e "const p=require('./package.json'); console.log(p.scripts && p.scripts.test ? 'yes' : 'no')" 2>/dev/null)
+  if [ "$HAS_TEST" = "yes" ]; then
+    echo "Running tests..."
+    bun test 2>&1 || npm test 2>&1 || echo "❌ FAIL: Tests failed"
+  else
+    echo "⚠ No test script found in package.json"
+  fi
+elif [ -f "pyproject.toml" ] || [ -f "pytest.ini" ]; then
+  echo "Running pytest..."
+  python -m pytest 2>&1 || echo "❌ FAIL: Tests failed"
+else
+  echo "⚠ No test runner detected"
+fi
+
+# 5. Type checking (if applicable)
+echo -e "\n--- Type Check ---"
+if [ -f "tsconfig.json" ]; then
+  echo "Running typecheck..."
+  npx tsc --noEmit 2>&1 || bun run typecheck 2>&1 || echo "⚠ Type errors detected"
+else
+  echo "⊘ Not applicable (no tsconfig.json)"
+fi
+
+echo -e "\n=== Pre-Deploy Summary ==="
+```
+
+**CRITICAL: Confirm with the user before proceeding to deployment.** Show what platform, environment, and branch will be deployed. Wait for explicit approval.
+
+### Phase 3: Deploy
+
+Execute platform-specific deployment. Always prefer commands documented in CLAUDE.md over auto-detected commands.
+
+**AWS CDK:**
+```bash
+cd infra && npx cdk deploy --all --require-approval broadening
+```
+
+**Railway:**
+```bash
+railway up --environment "$DEPLOY_ENV"
+```
+
+**Cloudflare Workers:**
+```bash
+wrangler deploy --env "$DEPLOY_ENV"
+```
+
+**AWS Amplify:**
+```bash
+# Amplify deploys on git push — just push the branch
+git push origin "$BRANCH"
+echo "Amplify will auto-deploy from branch: $BRANCH"
+```
+
+**Google Cloud Run:**
+```bash
+gcloud run deploy --source . --region us-west1
+```
+
+**GitHub Pages:**
+```bash
+git push origin "$BRANCH"
+echo "GitHub Actions will deploy to Pages"
+```
+
+### Phase 4: Post-Deploy Verification
+
+Use the deploy-verifier agent for post-deploy smoke testing.
+
+Invoke via Task tool:
+- `subagent_type`: "psd-claude-coding-system:deploy-verifier"
+- `description`: "Post-deploy verification for $DEPLOY_ENV"
+- `prompt`: "Verify deployment to $DEPLOY_ENV environment. Platform: $PLATFORM. Project path: [current directory]. Check: 1) Health endpoint responds, 2) No error logs in first 60 seconds, 3) Key routes return expected status codes. Report pass/fail for each check."
+
+### Phase 5: Summary
+
+```bash
+echo ""
+echo "=== Deployment Complete ==="
+echo "Project:     $(basename $(pwd))"
+echo "Platform:    $PLATFORM"
+echo "Environment: $DEPLOY_ENV"
+echo "Branch:      $BRANCH"
+echo "Commit:      $(git rev-parse --short HEAD)"
+echo "Time:        $(date)"
+echo ""
+echo "If issues arise, rollback options:"
+echo "  AWS CDK:      cd infra && npx cdk deploy --all (with reverted code)"
+echo "  Railway:       railway up (with reverted code)"
+echo "  Cloudflare:    wrangler rollback"
+echo "  Amplify:       git revert HEAD && git push"
+echo "  Cloud Run:     gcloud run services update-traffic --to-revisions=PREVIOUS"
+echo "  GitHub Pages:  git revert HEAD && git push"
+```
+
+## Success Criteria
+
+- ✅ All pre-deploy checks passed (clean tree, tests, types)
+- ✅ User confirmed deployment target before execution
+- ✅ Platform-specific deploy command executed
+- ✅ Post-deploy verification passed
+- ✅ Rollback instructions provided

--- a/plugins/psd-claude-coding-system/commands/doc_sync.md
+++ b/plugins/psd-claude-coding-system/commands/doc_sync.md
@@ -1,0 +1,111 @@
+---
+allowed-tools: Bash(*), View, Edit, Task
+description: Detect and fix documentation drift across project files
+argument-hint: [project path or 'all']
+model: claude-sonnet-4-5
+extended-thinking: true
+---
+
+# Documentation Freshness Checker
+
+You are a documentation auditor who detects drift between project documentation (CLAUDE.md, README.md) and the actual codebase. You identify stale claims, missing documentation, and broken references.
+
+**Target:** $ARGUMENTS
+
+## Workflow
+
+### Phase 1: Resolve Target
+
+```bash
+TARGET="$ARGUMENTS"
+
+if [ "$TARGET" = "all" ]; then
+  echo "=== Scanning all projects in ~/code/ ==="
+  PROJECTS=$(ls -d "$HOME/code"/*/ 2>/dev/null | while read d; do
+    [ -f "$d/CLAUDE.md" ] && echo "$d"
+  done)
+  echo "Projects with CLAUDE.md:"
+  echo "$PROJECTS"
+elif [ -d "$TARGET" ]; then
+  PROJECTS="$TARGET"
+elif [ -d "$HOME/code/$TARGET" ]; then
+  PROJECTS="$HOME/code/$TARGET"
+else
+  echo "❌ Project not found: $TARGET"
+  exit 1
+fi
+```
+
+### Phase 2: Invoke Documentation Auditor
+
+For each project, invoke the documentation-auditor agent:
+
+- `subagent_type`: "psd-claude-coding-system:documentation-auditor"
+- `description`: "Audit docs for [project name]"
+- `prompt`: "Audit documentation freshness for project at [path]. Cross-reference CLAUDE.md and README.md against actual codebase. Check: 1) Referenced file paths still exist, 2) Documented commands still work, 3) Listed dependencies match package.json/pyproject.toml, 4) Env vars documented match .env.example and actual usage, 5) Architecture descriptions match current code structure, 6) New significant files/dirs not mentioned in docs. Return structured findings as a drift report."
+
+If scanning multiple projects (`all`), invoke agents in parallel (up to 3 at a time).
+
+### Phase 3: Review Drift Report
+
+For each project, review the agent's findings and categorize:
+
+```
+## Documentation Drift Report: [project name]
+
+### 🔴 Broken References (must fix)
+- [file paths that no longer exist]
+- [commands that fail]
+- [env vars referenced but not used]
+
+### 🟡 Stale Content (should update)
+- [dependency versions that changed]
+- [architecture descriptions that diverged]
+- [feature descriptions for removed features]
+
+### 🟢 Missing Documentation (consider adding)
+- [new directories with no docs]
+- [new scripts with no description]
+- [new env vars with no documentation]
+
+### ✅ Accurate
+- [sections that are still correct]
+```
+
+### Phase 4: Fix (with user approval)
+
+For each finding, propose specific edits to CLAUDE.md or README.md. **Always ask user before applying fixes.**
+
+Group fixes by file and present as a batch:
+- Show the current text
+- Show the proposed replacement
+- Wait for approval before editing
+
+```bash
+echo "=== Proposed Fixes ==="
+echo "Files to update:"
+echo "  - CLAUDE.md: [N fixes]"
+echo "  - README.md: [N fixes]"
+echo ""
+echo "Apply fixes? (will show each change for approval)"
+```
+
+### Phase 5: Summary
+
+```bash
+echo "=== Doc Sync Complete ==="
+echo "Projects scanned: [count]"
+echo "Broken references found: [count]"
+echo "Stale content found: [count]"
+echo "Missing documentation: [count]"
+echo "Fixes applied: [count]"
+```
+
+## Success Criteria
+
+- ✅ All CLAUDE.md file path references validated
+- ✅ All documented commands verified as runnable
+- ✅ Dependency lists compared against actual manifests
+- ✅ Env vars cross-referenced between docs and code
+- ✅ New undocumented files/dirs identified
+- ✅ Fixes proposed with user approval before applying

--- a/plugins/psd-claude-coding-system/commands/project.md
+++ b/plugins/psd-claude-coding-system/commands/project.md
@@ -1,0 +1,116 @@
+---
+allowed-tools: Bash(*), View, Task
+description: Load project context and status briefing
+argument-hint: [project name or path]
+model: claude-sonnet-4-5
+---
+
+# Project Context Loader
+
+You are a project navigator that quickly loads context for a target project, giving the developer a fast status briefing to minimize context-switching cost.
+
+**Target:** $ARGUMENTS
+
+## Workflow
+
+### Phase 1: Resolve Project Path
+
+```bash
+# Resolve project path from name or path
+TARGET="$ARGUMENTS"
+
+# If it's just a name, check ~/code/
+if [ -d "$TARGET" ]; then
+  PROJECT_PATH="$TARGET"
+elif [ -d "$HOME/code/$TARGET" ]; then
+  PROJECT_PATH="$HOME/code/$TARGET"
+else
+  echo "❌ Project not found: $TARGET"
+  echo "Available projects in ~/code/:"
+  ls -d "$HOME/code"/*/ 2>/dev/null | xargs -I{} basename {}
+  exit 1
+fi
+
+echo "=== Project: $(basename $PROJECT_PATH) ==="
+echo "Path: $PROJECT_PATH"
+```
+
+### Phase 2: Read Project Configuration
+
+Read the following files from $PROJECT_PATH (skip any that don't exist):
+- `CLAUDE.md` — project conventions and architecture
+- `package.json` — dependencies, scripts, tech stack (if Node/Bun project)
+- `pyproject.toml` or `requirements.txt` — dependencies (if Python project)
+- `Cargo.toml` — dependencies (if Rust project)
+- `.env.example` or `.env.local.example` — required environment variables
+
+### Phase 3: Git & GitHub Status
+
+```bash
+cd "$PROJECT_PATH"
+
+echo "=== Git Status ==="
+git status --short
+
+echo -e "\n=== Recent Commits (last 10) ==="
+git log --oneline -10
+
+echo -e "\n=== Branches ==="
+git branch -a --sort=-committerdate | head -15
+
+echo -e "\n=== Open Issues ==="
+gh issue list --limit 5 2>/dev/null || echo "(no GitHub remote or gh not configured)"
+
+echo -e "\n=== Open PRs ==="
+gh pr list --limit 5 2>/dev/null || echo "(no GitHub remote or gh not configured)"
+```
+
+### Phase 4: Code Health Scan
+
+```bash
+cd "$PROJECT_PATH"
+
+echo "=== TODO/FIXME/HACK Items ==="
+grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.py" --include="*.swift" --include="*.rs" --include="*.go" --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=dist --exclude-dir=build --exclude-dir=target --exclude-dir=__pycache__ --exclude-dir=.git | head -20
+
+echo -e "\n=== Recently Modified Files (last 7 days) ==="
+find . -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.swift" -o -name "*.rs" \) -not -path "*/node_modules/*" -not -path "*/.next/*" -not -path "*/dist/*" -not -path "*/.git/*" -mtime -7 | head -20
+```
+
+### Phase 5: Output Briefing
+
+Synthesize all findings into a structured briefing:
+
+```
+## Project: [name]
+**Stack:** [detected from package.json/pyproject.toml/CLAUDE.md]
+**Path:** [full path]
+
+### Current State
+- Branch: [current branch]
+- Clean: [yes/no, uncommitted changes?]
+- Last commit: [date and message]
+
+### Open Work
+- Issues: [count and top 3 titles]
+- PRs: [count and top 3 titles]
+
+### Tech Debt
+- TODO/FIXME items: [count]
+- [Top 3 most important items]
+
+### Key Commands
+- Test: [from package.json scripts or CLAUDE.md]
+- Build: [from package.json scripts or CLAUDE.md]
+- Deploy: [from CLAUDE.md if documented]
+- Dev: [from package.json scripts or CLAUDE.md]
+```
+
+## Success Criteria
+
+- ✅ Project path resolved correctly
+- ✅ Tech stack identified
+- ✅ Git status and recent activity shown
+- ✅ Open issues and PRs listed
+- ✅ Code debt surfaced
+- ✅ Key commands extracted

--- a/plugins/psd-claude-coding-system/hooks/hooks.json
+++ b/plugins/psd-claude-coding-system/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/telemetry-init.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/plugin-auto-update.sh",
+            "timeout": 5
           }
         ]
       }

--- a/plugins/psd-claude-coding-system/scripts/plugin-auto-update.sh
+++ b/plugins/psd-claude-coding-system/scripts/plugin-auto-update.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# plugin-auto-update.sh
+#
+# SessionStart hook - Auto-update psd-claude-coding-system plugin
+# Called automatically when Claude Code session starts
+# Checks at most once per day to avoid slowing down every session
+#
+# Input: JSON via stdin with session_id, transcript_path, cwd, etc.
+# Output: Silent success (exit 0) or error to stderr (exit 2)
+
+# Read hook input JSON from stdin
+HOOK_INPUT=$(cat)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+STAMP_FILE="$PLUGIN_ROOT/meta/.last-update-check"
+
+# Only check once per day
+if [ -f "$STAMP_FILE" ]; then
+  LAST_CHECK=$(cat "$STAMP_FILE" 2>/dev/null)
+  TODAY=$(date +%Y-%m-%d)
+  if [ "$LAST_CHECK" = "$TODAY" ]; then
+    exit 0  # Already checked today
+  fi
+fi
+
+# Ensure meta directory exists
+mkdir -p "$PLUGIN_ROOT/meta" 2>/dev/null || exit 0
+
+# Run update in background so it doesn't block session start
+(
+  claude plugin update psd-claude-coding-system --scope user >/dev/null 2>&1
+  date +%Y-%m-%d > "$STAMP_FILE" 2>/dev/null
+) &
+
+exit 0


### PR DESCRIPTION
## Summary
- **`/project [name]`** — Loads project context briefing (tech stack, git status, open issues/PRs, TODOs, key commands) to reduce context-switching cost across multiple active apps
- **`/deploy [env]`** — Multi-platform deployment orchestration with pre-checks, auto-detection (AWS CDK, Railway, Cloudflare, Amplify, Cloud Run, GitHub Pages), and post-deploy verification
- **`/doc_sync [project|all]`** — Documentation drift detector that cross-references CLAUDE.md/README against actual codebase for stale paths, outdated deps, missing env vars, and undocumented content

## New files
| File | Type |
|------|------|
| `commands/project.md` | Command |
| `commands/deploy.md` | Command |
| `commands/doc_sync.md` | Command |
| `agents/deploy-verifier.md` | Agent — post-deploy smoke tests |
| `agents/documentation-auditor.md` | Agent — docs-vs-code drift detection |

## Test plan
- [ ] Verify commands appear in `/psd-claude-coding-system:` autocomplete after plugin reload
- [ ] `/project kangaroo` returns structured briefing
- [ ] `/deploy dev` runs pre-checks and detects platform
- [ ] `/doc_sync kangaroo` identifies documentation drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)