### PR TITLE
pdf-builder: tight tables in field_row (showLabels / gap / rowGap)

### DIFF
--- a/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
+++ b/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
@@ -164,12 +164,22 @@ class PDFBuilder:
         return y - 8
 
     def _draw_field_row(self, c, area, y, section):
-        """Draw a row of labeled input boxes. Returns new y position."""
+        """Draw a row of labeled input boxes. Returns new y position.
+
+        Options:
+          showLabels: bool (default True) — render labels above fields
+          rowGap: int (default FIELD_GAP) — vertical gap after the row
+          gap: int (default FIELD_GAP) — horizontal gap between fields
+        """
         fields = section.get("fields", [])
         if not fields:
             return y
 
-        total_gap = FIELD_GAP * (len(fields) - 1)
+        show_labels = section.get("showLabels", True)
+        h_gap = section.get("gap", FIELD_GAP)
+        row_gap = section.get("rowGap", FIELD_GAP)
+
+        total_gap = h_gap * (len(fields) - 1)
         total_width = area["width"] - total_gap
         x = area["x"]
 
@@ -183,18 +193,20 @@ class PDFBuilder:
         # For the row layout, use the tallest field's height
         row_height = max(f.get("height", FIELD_BOX_HEIGHT) for f in fields)
 
-        # Move down: label height + box height + padding
-        y -= (FIELD_LABEL_SIZE + row_height + 6)
+        # Move down: label height (if shown) + box height + padding
+        label_reserve = (FIELD_LABEL_SIZE + 4) if show_labels else 0
+        y -= (label_reserve + row_height + 2)
 
         # y is now at the bottom of the field box
         box_y = y
         for i, (field, fw) in enumerate(zip(fields, field_widths)):
             fh = field.get("height", FIELD_BOX_HEIGHT)
 
-            # Label above the box
-            c.setFont("Inter", FIELD_LABEL_SIZE)
-            c.setFillColor(PACIFIC)
-            c.drawString(x, box_y + fh + 3, field.get("label", ""))
+            # Label above the box (optional)
+            if show_labels:
+                c.setFont("Inter", FIELD_LABEL_SIZE)
+                c.setFillColor(PACIFIC)
+                c.drawString(x, box_y + fh + 3, field.get("label", ""))
 
             # Draw input box
             c.setStrokeColor(LIGHT_GRAY)
@@ -219,9 +231,9 @@ class PDFBuilder:
                 placeholder=field.get("placeholder", ""),
             )
 
-            x += fw + FIELD_GAP
+            x += fw + h_gap
 
-        return box_y - FIELD_GAP
+        return box_y - row_gap
 
     def _draw_checkbox_group(self, c, area, y, section):
         """Draw a vertical list of checkboxes. Returns new y position."""


### PR DESCRIPTION
## Summary
- Adds three optional section-level settings on `field_row` so a caller can render a proper table of form fields.
- `showLabels` (bool, default `true`) — skip per-field labels and reclaim the label-height vertical space.
- `gap` (int, default `FIELD_GAP`) — horizontal gap between cells. Set to `0` for flush adjacent boxes.
- `rowGap` (int, default `FIELD_GAP`) — vertical gap after the row. Set to `0` to stack rows with only the box stroke between them.

Existing specs render identically (defaults preserve old behavior).

## Motivation
The McKinney-Vento intake form needs a 6×6 student table. With the old `field_row`, rendering 36 cells produced 36 separately-labeled cells with gaps — not a table. This change lets the caller use one labeled header row and five flush data rows below it, which is what a student table should look like.

## Example
```json
{ "type": "field_row", "fields": [
  { "label": "First Name", "type": "TEXT", "width": 0.18 }, …
]},
{ "type": "field_row", "showLabels": false, "gap": 0, "rowGap": 0,
  "fields": [
    { "label": "S2 First", "type": "TEXT", "width": 0.18, "height": 14 }, …
  ]}
```

## Test plan
- [x] Existing specs (employment-agreement, permission-slip, contractor-agreement, etc.) render byte-identically — defaults unchanged.
- [x] McKinney-Vento intake template (ssd-mv-intake) renders with the new tight table as expected.
- [ ] Downstream Documenso field coordinates on new-style tables verified against the rendered PDF (same slug-per-label contract; callers supply unique labels).