### PR TITLE
Skill hardening from McKinney-Vento migration

### DIFF
--- a/plugins/psd-productivity/skills/documenso-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/documenso-manager/SKILL.md
@@ -182,6 +182,15 @@ Pre-fill TEXT fields with values via the API so signers see data without needing
 - **Items array is `envelopeItems`** — not `items`. Item IDs are string format: `envelope_item_xxxxx`.
 - **Same email for multiple recipients** may cause Documenso to skip sending signing emails (deduplication). Use different emails for testing.
 - **Distribute endpoint** — use raw JSON body with explicit `Content-Type: application/json` header. The n8n HTTP Request node's keypair body mode can produce malformed JSON.
+- **Distribute endpoint shape is `POST /api/v2/envelope/distribute`** with body `{"envelopeId":"envelope_xxx"}` — NOT path-based `/envelope/{id}/distribute` (that returns 404). Easy mistake when porting from other signing-service patterns.
+- **Envelope create payload requires `type: 'DOCUMENT'`** — missing this field causes HTTP 400 with `expected: 'DOCUMENT' | 'TEMPLATE', received: undefined`. When sent via n8n HTTP Request node with multipart-form-data, the 400 is misreported as `ECONNREFUSED`. Always include `type: 'DOCUMENT'` at the top of the payload object.
+- **Self-hosted Documenso respects `NEXT_PUBLIC_FEATURE_BILLING_ENABLED`** — when this env var is `true`, the instance applies free-plan limits (5 documents/month per user). Two fixes: (a) set the env var to `false` and rebuild (client-side bundle bakes it in), or (b) create a Team inside Documenso and issue API keys scoped to the team. Team-scoped keys bypass the per-user cap.
+- **API keys are team-scoped** — a key issued from a personal user account hits that user's quota. A key issued from a team has the team's (higher) limits. When rotating keys, verify the source context. Personal keys also cannot see team envelopes and vice versa.
+- **Webhooks are per-team, UI-only** — switching to a new team (or creating one) requires recreating the webhook subscription. No API to do this. Path: Documenso UI → team → Settings → Webhooks. URL: `https://n8n.psd401.net/webhook/documenso-completed`, event: `DOCUMENT_COMPLETED` or `ENVELOPE_COMPLETED` depending on version.
+- **Envelope `id` canonicalization** — two forms exist and are NOT interchangeable: (1) numeric integer in webhook payload (`payload.id: 104`, the internal `documentId`), and (2) string form from the API (`envelope_abc123`). Always canonicalize to the string form for cross-system matching (sheet rows, Drive metadata, audit logs). To resolve numeric → string: `GET /api/v2/envelope?query={title}` and read `.data[0].id`.
+- **Envelope email delivery depends on Documenso SMTP** — if SMTP config is broken, envelopes reach PENDING status with `sendStatus: SENT` in the API but signers never get emails. Bypass by giving signers their direct signing URL: `https://{DOCUMENSO_HOST}/sign/{recipient.token}`. The `token` is on each recipient in the envelope fetch response.
+- **Envelope fields come from `recipients[].fields`** — the top-level envelope GET response does NOT surface field metadata directly. To see what was pre-filled, inspect the signer's `fields` array inside recipients. Empty `fields: []` on a completed envelope means no pre-fill was submitted, not that data was lost.
+- **Always use `role: 'CC'` with empty `fields: []`** for read-only copy recipients. CC recipients count as "signed" automatically on envelope creation (their `signingStatus` is `SIGNED` even before anyone signs). They do not block completion.
 
 ## Recipient Roles Quick Reference
 
@@ -199,5 +208,6 @@ Pre-fill TEXT fields with values via the API so signers see data without needing
 |----------|----------|
 | `references/documenso-api-reference.md` | Full v2 API endpoints, field types (11), recipient roles (5), webhook events (13) |
 | `references/documenso-envelope-lifecycle.md` | DRAFT→PENDING→COMPLETED flow, field positioning guide, signing order, email settings |
+| `references/documenso-self-hosting-ops.md` | Self-hosted ops: billing-enabled mode, teams + API keys, webhook setup per-team, SMTP delivery, error→cause cheatsheet |
 | `references/psd-signing-templates.md` | 8 pre-built PSD template patterns with field positions |
 | `references/psd-signing-workflows.md` | End-to-end workflows for HR, board, student, vendor + n8n integration |

--- a/plugins/psd-productivity/skills/documenso-manager/references/documenso-api-reference.md
+++ b/plugins/psd-productivity/skills/documenso-manager/references/documenso-api-reference.md
@@ -15,12 +15,66 @@
 | GET | `/envelope` | List/search envelopes |
 | GET | `/envelope/{envelopeId}` | Get envelope details |
 | POST | `/envelope/update` | Update envelope metadata |
-| POST | `/envelope/distribute` | Send to recipients (DRAFT → PENDING) |
+| POST | `/envelope/distribute` | Send to recipients (DRAFT → PENDING) — body `{envelopeId}` |
 | POST | `/envelope/redistribute` | Resend to recipients |
 | POST | `/envelope/delete` | Delete envelope |
 | POST | `/envelope/duplicate` | Duplicate an envelope |
 | POST | `/envelope/use` | Create envelope from template |
 | GET | `/envelope/{envelopeId}/audit-log` | Retrieve audit log |
+
+### POST /envelope/create — required payload shape
+
+`type: 'DOCUMENT'` is REQUIRED. Omitting it returns HTTP 400 with `expected: 'DOCUMENT' | 'TEMPLATE', received: undefined`. From n8n's HTTP Request node with multipart-form-data, this 400 surfaces as a misleading `ECONNREFUSED` error.
+
+```json
+{
+  "type": "DOCUMENT",
+  "title": "MV Intake - Doe (TECH SUPPORT) - 2026-04-22",
+  "recipients": [
+    { "email": "...", "name": "...", "role": "SIGNER", "signingOrder": 1, "fields": [...] },
+    { "email": "...", "name": "...", "role": "CC",     "signingOrder": 2, "fields": [] }
+  ],
+  "meta": {
+    "subject": "...",
+    "message": "...",
+    "timezone": "America/Los_Angeles",
+    "dateFormat": "MM/dd/yyyy",
+    "distributionMethod": "EMAIL",
+    "signingOrder": "SEQUENTIAL",
+    "typedSignatureEnabled": true,
+    "drawSignatureEnabled": true
+  }
+}
+```
+
+Multipart upload: send the JSON above as a `payload` form field plus the PDF as `files` binary form field.
+
+### POST /envelope/distribute — endpoint shape
+
+The distribute endpoint is `/api/v2/envelope/distribute` with body `{"envelopeId":"envelope_xxx"}`. **NOT** `/api/v2/envelope/{id}/distribute` — that path returns 404. Common porting mistake from other signing-service patterns.
+
+```bash
+curl -X POST https://documenso.psd401.net/api/v2/envelope/distribute \
+  -H "Authorization: api_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"envelopeId":"envelope_abc123"}'
+```
+
+### Envelope ID forms (canonicalize to string)
+
+Two ID forms exist and they are NOT interchangeable:
+
+| Form | Where it appears | Example |
+|------|------------------|---------|
+| Numeric integer | Webhook payload `payload.id`, internal `documentId` | `104` |
+| String | Top-level API responses, search results, all path params | `envelope_abc123xyz` |
+
+**Rule:** always canonicalize to the string form for cross-system matching (sheet rows, Drive metadata, audit logs, downstream node lookups). When a webhook fires with a numeric id, resolve it via search:
+
+```
+GET /envelope?query={title}
+→ data[0].id  (the string form)
+```
 
 ### Search Parameters (GET /envelope)
 

--- a/plugins/psd-productivity/skills/documenso-manager/references/documenso-self-hosting-ops.md
+++ b/plugins/psd-productivity/skills/documenso-manager/references/documenso-self-hosting-ops.md
@@ -49,7 +49,7 @@ A key issued from a personal user account has that user's quota and visibility. 
 - A new team key cannot see envelopes that were created with the old personal key
 - Webhooks fired by old-context envelopes won't include the new context
 
-**Key rotation procedure** (see `n8n-manager/scripts/rotate_documenso_key.sh` if implemented):
+**Key rotation procedure** (see `n8n-manager/scripts/rotate_documenso_key.js` if implemented):
 1. Issue new key in Documenso UI (team settings)
 2. Find all n8n workflows that reference the old key (grep for `api_` prefix in workflow JSON)
 3. For each workflow: `get_workflow.js → string-replace key → update_workflow.js`

--- a/plugins/psd-productivity/skills/documenso-manager/references/documenso-self-hosting-ops.md
+++ b/plugins/psd-productivity/skills/documenso-manager/references/documenso-self-hosting-ops.md
@@ -1,0 +1,160 @@
+# Documenso Self-Hosting Operations Guide
+
+Operational knowledge for the PSD self-hosted Documenso instance at `documenso.psd401.net`. Captures the gotchas around teams, webhooks, billing limits, email delivery, and API key rotation that have bitten real workflows.
+
+---
+
+## Billing-enabled mode applies free-plan limits
+
+When `NEXT_PUBLIC_FEATURE_BILLING_ENABLED=true` is set on the Documenso server, the instance treats the user as a Free Plan cloud user and enforces a **5 documents/month** cap per user. Symptom: `LIMIT_EXCEEDED` error from `POST /envelope/create` after 5 envelopes in a calendar month.
+
+### Two ways to remove the cap
+
+**Option A — disable billing flag (recommended for fully self-hosted, single-tenant):**
+
+1. SSH to the Documenso server
+2. Edit `.env` (or compose env block): `NEXT_PUBLIC_FEATURE_BILLING_ENABLED=false`
+3. Rebuild the container — the flag is `NEXT_PUBLIC_*` so it's baked into the client bundle at build time, env reload alone does not propagate it
+4. `docker compose up -d --force-recreate documenso`
+
+**Option B — use Teams (recommended when billing-enabled mode must stay on):**
+
+1. In the Documenso UI, create a Team
+2. Issue an API key from the team's settings (NOT from the personal user account)
+3. Use that team-scoped API key in n8n workflows
+
+Team-scoped API keys bypass the per-user free-plan cap. Personal-account keys remain limited.
+
+### Code reference
+
+The limit check lives in `packages/ee/server-only/limits/server.ts` upstream:
+
+```typescript
+if (!IS_BILLING_ENABLED()) {
+  return { quota: SELFHOSTED_PLAN_LIMITS, ... };  // unlimited
+}
+// ...falls through to FREE_PLAN_LIMITS (5 docs/month)
+```
+
+And `IS_BILLING_ENABLED` resolves to `env('NEXT_PUBLIC_FEATURE_BILLING_ENABLED') === 'true'`.
+
+---
+
+## API keys are team-scoped
+
+A key issued from a personal user account has that user's quota and visibility. A key issued from a Team has the team's quota and only sees envelopes within the team.
+
+**When rotating keys:**
+- Verify the source context (personal vs team) — they are not equivalent
+- A new team key cannot see envelopes that were created with the old personal key
+- Webhooks fired by old-context envelopes won't include the new context
+
+**Key rotation procedure** (see `n8n-manager/scripts/rotate_documenso_key.sh` if implemented):
+1. Issue new key in Documenso UI (team settings)
+2. Find all n8n workflows that reference the old key (grep for `api_` prefix in workflow JSON)
+3. For each workflow: `get_workflow.js → string-replace key → update_workflow.js`
+4. Re-snapshot all updated workflows to the repo
+5. Test with a probe call before relying on production traffic
+
+---
+
+## Webhooks are per-team, UI-only
+
+Documenso has no API to list, create, or delete webhook subscriptions. They are managed in the UI at `Settings → Webhooks` (per-team).
+
+**When creating a new team OR issuing a new team key:**
+The webhook subscription does NOT carry over from the old context. The router at `https://n8n.psd401.net/webhook/documenso-completed` must be re-added in the new team's webhook settings:
+
+| Field | Value |
+|-------|-------|
+| URL | `https://n8n.psd401.net/webhook/documenso-completed` |
+| Event | `DOCUMENT_COMPLETED` (older versions) or `ENVELOPE_COMPLETED` (newer) |
+| Active | yes |
+| Secret | optional but recommended; if used, n8n must validate signature |
+
+**Symptom of a missing webhook:** envelopes complete (status → COMPLETED in Documenso UI), signed PDFs exist on the server, but no n8n router execution fires. Drive folder stays empty, completion email never sends, sheet row never updates. Silent.
+
+### Diagnostic for "router never fires"
+
+```bash
+# Are envelopes actually reaching COMPLETED state?
+curl -s "https://documenso.psd401.net/api/v2/envelope?status=COMPLETED" \
+  -H "Authorization: api_xxx" | jq '.data[] | {id, title, completedAt}'
+
+# Has the router seen any executions in the last 24 hours?
+# (via n8n list_executions.js — workflowId is the router's ID)
+bun list_executions.js '{"workflowId":"<router-id>","limit":10}'
+
+# If completed envelopes exist but router has zero recent executions,
+# the webhook subscription is missing or pointing at the wrong URL.
+```
+
+---
+
+## Email delivery depends on Documenso SMTP
+
+Documenso's `distributionMethod: 'EMAIL'` relies on the instance's SMTP config. If SMTP is broken (bad credentials, blocked port, expired Mailgun account), envelopes still distribute and reach `PENDING` with each recipient's `sendStatus: SENT` in the API — but no signing emails actually reach inboxes.
+
+### SMTP environment variables
+
+| Var | Purpose |
+|-----|---------|
+| `NEXT_PRIVATE_SMTP_TRANSPORT` | `smtp` / `mailchannels` / `resend` |
+| `NEXT_PRIVATE_SMTP_HOST` | Server hostname |
+| `NEXT_PRIVATE_SMTP_PORT` | Usually 587 or 465 |
+| `NEXT_PRIVATE_SMTP_USERNAME` | Auth user |
+| `NEXT_PRIVATE_SMTP_PASSWORD` | Auth pass |
+| `NEXT_PRIVATE_SMTP_FROM_NAME` | Display name |
+| `NEXT_PRIVATE_SMTP_FROM_ADDRESS` | From: address |
+
+### Bypass when email is broken
+
+Each recipient has a `token` in the envelope GET response. Signing URL:
+
+```
+https://{DOCUMENSO_HOST}/sign/{recipient.token}
+```
+
+Send this URL via another channel (Slack, n8n Gmail node, etc.) and the signer can complete without the Documenso-generated email.
+
+### Diagnostic for "envelope distributed but no email"
+
+```bash
+# Check what Documenso thinks happened
+curl -s "https://documenso.psd401.net/api/v2/envelope/{id}" -H "Authorization: api_xxx" \
+  | jq '.recipients[] | {role, email, sendStatus, signingStatus, token}'
+
+# All sendStatus: SENT but recipients aren't getting emails → SMTP broken.
+# Check Documenso server logs for SMTP errors.
+docker logs documenso 2>&1 | grep -iE 'smtp|email|mail' | tail -50
+```
+
+---
+
+## Recipient role behavior
+
+| Role | Receives email | Blocks completion | Auto-marked SIGNED on create |
+|------|---------------|-------------------|------------------------------|
+| SIGNER | Yes (signing link) | Yes | No |
+| APPROVER | Yes (approval link) | Yes | No |
+| CC | Yes (final completed copy) | No | Yes |
+| VIEWER | Yes (view link) | No | Yes |
+| ASSISTANT | Yes (fill link) | No | Yes |
+
+**CC recipients are auto-SIGNED on envelope creation.** Their `signingStatus` is `SIGNED` even before any signer has done anything. They get a copy of the completed PDF when the envelope reaches COMPLETED.
+
+When you want a recipient to receive a styled n8n-built email instead of Documenso's default completion email, **remove them from `recipients` entirely** and have your completion handler send the branded email separately.
+
+---
+
+## Common error → real cause cheatsheet
+
+| Error message | Real cause | Fix |
+|---------------|-----------|-----|
+| `ECONNREFUSED` from n8n on `/envelope/create` | Documenso 400 (validation) masked by n8n multipart handling | Replay payload via curl; usually missing `type: 'DOCUMENT'` |
+| `LIMIT_EXCEEDED` | Free-plan billing cap on personal user account | Use a team-scoped API key OR disable `NEXT_PUBLIC_FEATURE_BILLING_ENABLED` |
+| `Resource not found` (404) on distribute | Wrong endpoint shape | Use `POST /envelope/distribute` with body `{envelopeId}`, not path-based `/envelope/{id}/distribute` |
+| `Workflow does not exist` (in n8n executeWorkflow node) | n8n issue, not Documenso | Bump executeWorkflow node `typeVersion` to 1.2 |
+| Envelope completes but n8n doesn't fire | Webhook subscription missing for the team | Re-add webhook in Documenso UI under team settings |
+| Envelope distributed but signers don't get email | Documenso SMTP broken | Send signing URL `https://{host}/sign/{token}` directly via another channel |
+| Sheet row missing for completed envelope | envelope_id form mismatch (numeric vs string) | Canonicalize to string `envelope_xxx` in both the intake write AND the handler match |

--- a/plugins/psd-productivity/skills/n8n-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/n8n-manager/SKILL.md
@@ -80,6 +80,7 @@ PSD runs n8n Community Edition. These features are **not available**:
 | `/n8n vars` | `bun list_variables.js` | List variables |
 | `/n8n var-create <key> <val>` | `bun create_variable.js <key> <val>` | Create variable |
 | `/n8n audit` | `bun run_audit.js` | Security audit |
+| `/n8n rotate-documenso-key <old> <new>` | `bun rotate_documenso_key.js <old> <new>` | Rotate the Documenso API key across every workflow that uses it. Add `--dry-run` first to preview. |
 
 ### Folder & Organization (MCP-based)
 
@@ -208,6 +209,18 @@ Returns the workflow ID and editor URL.
 - **Webhook paths don't support route parameters** — `path: "template/:name"` returns 404. Use query parameters instead: `path: "psd-template"` with `?name=value`.
 - **Google Drive v3 download bug** — the download operation calls the export API, causing "Export only supports Docs Editors files" for uploaded PDFs. Use the template server pattern or HTTP Request with `?alt=media&supportsAllDrives=true`.
 - **Google Sheets auto-map pitfall** — `autoMapInputData` creates duplicate columns if JSON keys don't match headers exactly (including whitespace). Use a Code node to format keys before the Sheets node.
+- **Google Sheets Update returns empty output** — the `update` operation on `n8n-nodes-base.googleSheets` v4.5 normally emits zero items on success, which breaks downstream chains silently. Set `"alwaysOutputData": true` on every Update node whose output is consumed by a later node (Read, Email, etc.).
+- **Google Sheets filtered-read can silently return zero rows** — `filtersUI` with `lookupColumn`/`lookupValue` intermittently returns empty even when the row exists; seen with `sheetName.mode='name' value='Sheet1'`. Fallback is a direct HTTP Request to `https://sheets.googleapis.com/v4/spreadsheets/{id}/values/{range}` via `predefinedCredentialType: googleSheetsOAuth2Api`, then filter client-side in a Code node. Reliable.
+- **Google Sheets sheetName mode mismatch** — some sheets work with `{mode: 'name', value: 'Sheet1'}` and others only with `{mode: 'id', value: 'gid=0'}`. When a Sheets node "Sheet with name X not found," try the other form. Employee Directory (`16iyRqjWoeeXLrrcyP6EOGWL8JKutd-rMBuDzvkNtK38`) requires `gid=0`.
+- **Switch node v3.2 silently routes to output 0** if rules are missing full structure. Every rule's `conditions` object MUST include `options.typeValidation: 'strict'`, `options.version: 2`, `combinator: 'and'`, and each condition needs `operator.name` (e.g. `'filter.operator.equals'`) in addition to `type`/`operation`. Rules built with only the minimal `{leftValue, rightValue, operator: {type, operation}}` match the first rule on every input.
+- **Switch fallback output requires `options.fallbackOutput: 'extra'`** — without it, unmatched inputs are silently dropped. With it, an additional output is added at the end of the rules array for "no rule matched" traffic.
+- **executeWorkflow typeVersion 1.0 is broken** — throws `Workflow does not exist` at runtime even when the sub-workflow exists and is active. Always deploy `n8n-nodes-base.executeWorkflow` with `typeVersion: 1.2`. Sub-workflow resolution in v1.0 is effectively dead.
+- **Sub-workflows must be activated before the caller is saved** — deploying a parent workflow that calls an inactive sub-workflow fails with `Cannot publish workflow: Node X references workflow Y which is not published`. Activate the sub-workflow first, THEN deploy the parent.
+- **Gmail node `senderName` silently drops messages** — setting `options.senderName` without a matching Google Workspace send-as alias causes Gmail to accept the message, return a valid message ID with SENT label, and never deliver. Omit `senderName` unless a Workspace alias is configured for the credentialed account.
+- **Gmail node default footer leaks** — `options.appendAttribution` defaults to `true`, appending "Automated with n8n" to branded emails. Always explicitly set `options.appendAttribution: false` on every Gmail node.
+- **Stale snapshot regressions** — `update_workflow.js` is a full PUT. If a script rebuilds a workflow from a snapshot taken before another fix was deployed, the earlier fix silently reverts. Every modify MUST be preceded by a `get_workflow.js` call in the same script run; never re-use an older snapshot even minutes later.
+- **HTTP Request `=` prefix on literal fields** — fields built by the n8n UI store string literals as `=value` (expression-mode with no interpolation). Build scripts that write `"value": "plain"` work for most cases but can trigger subtle bugs in multipart body encoding. Prefer `"=plain"` to match UI-built shape.
+- **n8n masks Documenso 400 errors as ECONNREFUSED** — when `POST /api/v2/envelope/create` returns HTTP 400 with a JSON validation error (e.g. missing `type: 'DOCUMENT'`), the n8n HTTP Request node with multipart-form-data reports it as `The service refused the connection - perhaps it is offline` / `ECONNREFUSED`. Always replay a failing Documenso payload via `curl` from the host to see the real error body.
 
 ## PSD Systems Quick Reference
 
@@ -226,6 +239,7 @@ See `references/psd-integration-map.md` for full details including workspace IDs
 | Document | Contents |
 |----------|----------|
 | `references/n8n-workflow-json-spec.md` | Workflow JSON structure, connection model, expression syntax |
-| `references/n8n-node-catalog.md` | Common nodes with JSON snippets (Webhook, Form, HTTP, Code, IF, Slack, Google) |
+| `references/n8n-node-catalog.md` | Common nodes with JSON snippets (Webhook, Form, HTTP, Code, IF, Slack, Google) — includes the canonical Switch v3.2, executeWorkflow v1.2, Gmail v2.1, and Documenso multipart/distribute HTTP shapes |
 | `references/psd-integration-map.md` | PSD systems → n8n nodes, credentials, auth methods, endpoints |
 | `references/psd-workflow-templates.md` | 10 pre-built PSD workflow patterns with node configs |
+| `references/documenso-n8n-patterns.md` | Submission + completion-handler + router patterns for the DocuSign→Documenso migration; title-prefix routing convention; debug flow when "nothing happens" |

--- a/plugins/psd-productivity/skills/n8n-manager/references/documenso-n8n-patterns.md
+++ b/plugins/psd-productivity/skills/n8n-manager/references/documenso-n8n-patterns.md
@@ -1,0 +1,261 @@
+# Documenso ↔ n8n Workflow Patterns (PSD)
+
+Canonical patterns for the PSD DocuSign → Documenso migration. Every new signing workflow follows one of these shapes. Cross-references `documenso-manager` skill for API specifics.
+
+---
+
+## 1. Submission workflow (form → Documenso envelope)
+
+The standard "user fills a form, system creates a Documenso envelope for them to sign" pattern.
+
+### Node chain
+
+```
+Form Trigger (page 1 — email or login)
+  → Lookup In Directory (Google Sheets read, gid=0 mode)
+  → Build Page 2 Form Definition (Code → returns jsonOutput string)
+  → Form (page 2 — defineForm: "json")
+  → Read Template PDF (HTTP Request to template-server webhook)
+  → Build Documenso Payload (Code — includes type:'DOCUMENT')
+  → Create Documenso Envelope (HTTP multipart)
+  → Distribute Envelope (HTTP raw JSON)
+  → Prep Sheet Row (Code — sets envelope_id to STRING form)
+  → Log Intake to Sheet (Sheets append)
+```
+
+### Required configurations (each step)
+
+**Form Trigger (page 1):**
+- First field MUST be the PSD logo iframe HTML (`<iframe src="https://n8n.psd401.net/webhook/psd-logo">`)
+- Set `options.customCss` with the standard PSD CSS (--container-width: 900px, Pacific colors, etc.)
+- Set `options.appendAttribution: false`
+- After ANY change to `customCss`, deactivate + reactivate the workflow to bust the cached form HTML
+
+**Form (page 2 — dynamic):**
+- `defineForm: "json"`, `jsonOutput: "={{ $json.intakeFormDefinition }}"`
+- First field of the JSON definition MUST be the same logo HTML block
+- Same `options.customCss`, `appendAttribution: false`
+- For multi-select-like UX, prefer multiple Yes/No dropdowns over checkbox_group (n8n form HTML strips inline classes anyway)
+
+**Build Documenso Payload (Code):**
+```js
+var payload = {
+  type: 'DOCUMENT',  // REQUIRED — without this, n8n reports ECONNREFUSED instead of the real 400
+  title: '<doc-prefix> - <last-name> (<bldg>) - <YYYY-MM-DD>',  // prefix matches router detection
+  recipients: [
+    { email: signerEmail, name: signerName, role: 'SIGNER', signingOrder: 1, fields: prefilledFields.concat(sigFields) }
+    // CC recipients omitted — completion handler sends branded email instead of letting Documenso send the default
+  ],
+  meta: {
+    subject: '...',
+    message: '...',
+    timezone: 'America/Los_Angeles',
+    dateFormat: 'MM/dd/yyyy',
+    distributionMethod: 'EMAIL',
+    signingOrder: 'SEQUENTIAL',
+    typedSignatureEnabled: true,
+    drawSignatureEnabled: true
+  }
+};
+return [{ json: { payload: JSON.stringify(payload), envelopeTitle: payload.title, rowFlat: rowFlat }, binary: $input.first().binary }];
+```
+
+**Create Documenso Envelope (HTTP):**
+- See `n8n-node-catalog.md` → "HTTP Request — Documenso envelope create (multipart)"
+- The payload JSON must be a `multipart-form-data` field named `payload` (NOT JSON body)
+- The PDF binary is a `formBinaryData` field named `files`
+
+**Distribute Envelope (HTTP):**
+- See `n8n-node-catalog.md` → "HTTP Request — Documenso envelope distribute (raw JSON)"
+- Endpoint is `/api/v2/envelope/distribute` (NOT path-based)
+- Body: `{"envelopeId":"{{ $json.id }}"}` — the `id` from Create's response is already in string form
+
+**Prep Sheet Row (Code):**
+```js
+var envelope = $input.first().json;  // Distribute response, includes id as envelope_xxx
+var rowFlat = $('Build Documenso Payload').first().json.rowFlat;
+rowFlat.envelope_id = envelope.id || '';  // STRING form — canonical
+return [{ json: rowFlat }];
+```
+
+**Log Intake to Sheet (Google Sheets append):**
+- `mappingMode: 'autoMapInputData'` — JSON keys must match sheet headers EXACTLY (no extra whitespace)
+- Tab name: try `{mode: 'name', value: 'Sheet1'}` first; if "not found", try `{mode: 'id', value: 'gid=0'}`
+
+### Why no CC recipients on the envelope
+
+If you add `role: 'CC'` recipients to the Documenso payload, those people receive Documenso's default completion email (raw, unbranded, with the signed PDF attached). For PSD-quality UX, **send a branded HTML email from the completion handler instead** — see Pattern 2 below.
+
+---
+
+## 2. Completion handler (Documenso webhook → Drive + Sheet + Email)
+
+Triggered by the document completion router (`Documenso - Document Completion Router`) which routes by envelope title prefix to per-document-type handlers.
+
+### Node chain
+
+```
+Execute Workflow Trigger (typeVersion 1)
+  → Extract Envelope Data (Code — from webhook payload)
+  → Find Envelope String ID (HTTP search by title)
+  → Extract String ID (Code — resolve numeric → envelope_xxx string)
+  → Get Envelope Items (HTTP)
+  → Build Download URL (Code)
+  → Download Signed PDF (HTTP file response)
+  → Upload to Drive (Google Drive)
+  → Prep Sheet Update (Code — uses STRING envelope_id)
+  → Update Sheet Row (Sheets — alwaysOutputData: true!)
+  → Read Full Row (HTTP to Sheets API — bypasses filtersUI bug)
+  → Build Notification Email (Code — branded HTML, finds row client-side)
+  → Send Notification (Gmail — appendAttribution: false, no senderName)
+```
+
+### Required configurations
+
+**Execute Workflow Trigger:** typeVersion `1` is correct here (this is the trigger node, not the executor in the parent). The PARENT'S `executeWorkflow` node must be `typeVersion: 1.2` to call this.
+
+**Extract Envelope Data (Code):** the webhook payload's `id` is numeric. Save it but don't try to use it for downstream API calls. Pass `title` to the next step.
+
+**Find Envelope String ID (HTTP):**
+```
+GET https://documenso.psd401.net/api/v2/envelope?query={{ $json.title }}
+Authorization: api_xxx
+```
+Returns up to N envelopes matching the title. Filter for `status === 'COMPLETED'` in the next Code node.
+
+**Extract String ID (Code):**
+```js
+var search = $input.first().json;
+var prev = $('Extract Envelope Data').first().json;
+var envelopes = search.data || [];
+var env = envelopes.find(e => e.status === 'COMPLETED') || envelopes[0];
+if (!env) throw new Error('No envelope for: ' + prev.title);
+return [{ json: { envelopeStringId: env.id, /* ... */ } }];
+```
+
+**Update Sheet Row (Google Sheets):**
+- `operation: 'update'`, `matchingColumns: ['envelope_id']`
+- **Set `alwaysOutputData: true`** — without it, the chain dies after this node because Update returns zero items
+- The `envelope_id` column value MUST be the STRING form (matches what intake wrote)
+
+**Read Full Row (HTTP — NOT Google Sheets node):**
+```json
+{
+  "method": "GET",
+  "url": "https://sheets.googleapis.com/v4/spreadsheets/<id>/values/Sheet1",
+  "authentication": "predefinedCredentialType",
+  "nodeCredentialType": "googleSheetsOAuth2Api"
+}
+```
+Returns `{values: [[headers], [row1], [row2], ...]}`. Filter client-side in the next Code node — the n8n Sheets node's filtered read is unreliable (sometimes returns 0 rows for valid filters).
+
+**Build Notification Email (Code):**
+```js
+var envelopeId = $('Prep Sheet Update').first().json.envelope_id;
+var resp = $input.first().json;
+var values = (resp && resp.values) || [];
+var headers = values[0] || [];
+var row = { envelope_id: envelopeId, /* fallback empties */ };
+for (var i = 1; i < values.length; i++) {
+  var rec = {};
+  for (var c = 0; c < headers.length; c++) rec[headers[c]] = values[i][c];
+  if (String(rec.envelope_id) === String(envelopeId)) { row = rec; break; }
+}
+// ...build branded HTML using row's fields...
+return [{ json: { emailHtml, subject, recipients: 'a@x.com, b@x.com' } }];
+```
+
+**Send Notification (Gmail v2.1):**
+- `options.appendAttribution: false` (mandatory — default is `true` and leaks "Automated with n8n" footer)
+- Do NOT set `options.senderName` unless a Workspace alias is configured (silent delivery failure)
+- `sendTo` accepts comma-separated string for multi-recipient
+
+---
+
+## 3. Document Completion Router
+
+Single shared workflow that receives every Documenso `DOCUMENT_COMPLETED` webhook and dispatches to the appropriate per-type handler based on envelope title prefix.
+
+### Node chain
+
+```
+Documenso Webhook (path: documenso-completed)
+  → Extract Document Info (Code — title prefix → documentType)
+  → Route by Document Type (Switch v3.2)
+  → [output 0] Handle Evaluation     → Eval Completion Handler
+  → [output 1] Handle File Only      → File-Only Completion Handler
+  → [output 2] Handle Transfer       → Transfer Completion Handler
+  → [output 3] Handle MV Intake      → MV Completion Handler
+  → [output N] (fallback)            → Log Unknown Document
+```
+
+### Required configurations
+
+**Switch v3.2:** see `n8n-node-catalog.md` for the full required rule structure. Without `combinator: 'and'` + `operator.name` + `options.typeValidation`, the switch silently routes everything to output 0.
+
+**Switch fallback:** `options.fallbackOutput: 'extra'` adds a final output for unmatched inputs. Wire to a Log Unknown Document node so unknowns are visible in execution history.
+
+**executeWorkflow nodes (Handle ...):** every one MUST be `typeVersion: 1.2`. Version 1.0 throws `Workflow does not exist` at runtime even when the target is active.
+
+**Activation order:** every sub-workflow (handler) must be active BEFORE the router is saved with the reference. Otherwise deploy fails with `Cannot publish workflow: Node X references workflow Y which is not published`.
+
+---
+
+## 4. Title prefix routing convention
+
+The router detects document type from the envelope title's prefix. Each new document type adds a clause to `Extract Document Info` and a switch rule + handler.
+
+| Title prefix | documentType | Handler |
+|--------------|--------------|---------|
+| `Performance Evaluation` | `evaluation` | Eval Completion Handler |
+| `Central Leadership Evaluation` | `evaluation` | Eval Completion Handler |
+| `Counselor-ESA Evaluation` | `file-only` | File-Only Completion Handler |
+| `TSD Certificated Timesheet` | `file-only` | File-Only Completion Handler |
+| `COI Disclosure` | `file-only` | File-Only Completion Handler |
+| `Within District Transfer` | `transfer` | Transfer Completion Handler |
+| `Non-Resident Transfer` | `transfer` | Transfer Completion Handler |
+| `MV Intake` | `mv-intake` | MV Completion Handler |
+| _(everything else)_ | `unknown` | Log Unknown Document |
+
+When adding a new document type:
+1. Add the prefix → documentType branch in router's `Extract Document Info` Code node
+2. Add a Switch rule with the new `documentType` value (full v3.2 structure!)
+3. Build the new completion handler workflow following Pattern 2
+4. Activate the handler
+5. Add a `Handle <Type>` executeWorkflow node (typeVersion 1.2) wired from the new switch output
+6. Save the router (deploy will fail if the handler isn't active first)
+
+---
+
+## 5. Self-hosted billing trap
+
+If `LIMIT_EXCEEDED` errors start appearing on `POST /envelope/create` after exactly 5 envelopes/month, the Documenso instance has billing enabled and the API key is scoped to a personal user (free plan).
+
+**Quick fix:** issue a new API key from inside a Documenso Team (UI → team settings) and use the rotation script:
+
+```bash
+bun rotate_documenso_key.js api_oldkey api_newteamkey
+```
+
+**Permanent fix:** disable `NEXT_PUBLIC_FEATURE_BILLING_ENABLED` on the Documenso server and rebuild.
+
+See `documenso-manager/references/documenso-self-hosting-ops.md` for the full breakdown.
+
+---
+
+## 6. Common debug flow when "nothing happens"
+
+When a user submits a form, signs the envelope, and nothing downstream fires:
+
+1. **Check Documenso UI** — is the envelope at COMPLETED status?
+   - No → signing flow is broken (email delivery? signing URL?). Use the recipient's `token` to bypass: `https://documenso.psd401.net/sign/{token}`
+   - Yes → continue
+2. **Check the router workflow's executions**
+   - No execution at the completion timestamp → Documenso webhook subscription is missing for this team. Re-add in UI.
+   - Execution exists but errored → see the error
+   - Execution exists and succeeded → continue
+3. **Check the appropriate handler's executions**
+   - No execution → router routed to wrong output (Switch v3.2 rule structure?), OR executeWorkflow node typeVersion is 1.0
+   - Execution exists but errored → drill into the failed node
+4. **For "not found" data in completion email** → envelope_id form mismatch (numeric vs string) between intake and handler
+5. **For ECONNREFUSED on Documenso calls from n8n** when laptop curl works → 1) check probe workflow, 2) replay payload via curl from n8n's host, 3) likely missing `type: 'DOCUMENT'` or other 400 being misreported

--- a/plugins/psd-productivity/skills/n8n-manager/references/n8n-node-catalog.md
+++ b/plugins/psd-productivity/skills/n8n-manager/references/n8n-node-catalog.md
@@ -224,8 +224,8 @@ Conditional branching. Output 0 = true, Output 1 = false.
 }
 ```
 
-### Switch (`n8n-nodes-base.switch`)
-Multi-branch routing based on a value.
+### Switch (`n8n-nodes-base.switch`) — v3.2
+Multi-branch routing based on a value. **Every rule MUST include the full structure below.** Missing `options.typeValidation`, `options.version`, `combinator`, or `operator.name` causes n8n to silently route all inputs to output 0 regardless of the value being tested.
 
 ```json
 {
@@ -234,17 +234,60 @@ Multi-branch routing based on a value.
   "typeVersion": 3.2,
   "position": [500, 300],
   "parameters": {
-    "mode": "rules",
     "rules": {
       "values": [
-        { "conditions": { "conditions": [{ "leftValue": "={{ $json.category }}", "rightValue": "hardware", "operator": { "type": "string", "operation": "equals" } }] }, "outputKey": "Hardware" },
-        { "conditions": { "conditions": [{ "leftValue": "={{ $json.category }}", "rightValue": "software", "operator": { "type": "string", "operation": "equals" } }] }, "outputKey": "Software" }
+        {
+          "conditions": {
+            "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict", "version": 2 },
+            "conditions": [{
+              "id": "<uuid-v4>",
+              "leftValue": "={{ $json.category }}",
+              "rightValue": "hardware",
+              "operator": { "type": "string", "operation": "equals", "name": "filter.operator.equals" }
+            }],
+            "combinator": "and"
+          },
+          "renameOutput": false
+        },
+        {
+          "conditions": {
+            "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict", "version": 2 },
+            "conditions": [{
+              "id": "<uuid-v4>",
+              "leftValue": "={{ $json.category }}",
+              "rightValue": "software",
+              "operator": { "type": "string", "operation": "equals", "name": "filter.operator.equals" }
+            }],
+            "combinator": "and"
+          },
+          "renameOutput": false
+        }
       ]
     },
-    "fallbackOutput": "extra"
+    "options": { "fallbackOutput": "extra" }
   }
 }
 ```
+
+**`fallbackOutput: "extra"`** — adds a final output for inputs that match no rule. Connect a fallback/log node to the last switch output.
+
+### Execute Workflow (`n8n-nodes-base.executeWorkflow`) — v1.2
+Calls a sub-workflow by ID. **Always use `typeVersion: 1.2`.** Version 1.0 throws `Workflow does not exist` at runtime even when the target is active.
+
+```json
+{
+  "name": "Handle Completion",
+  "type": "n8n-nodes-base.executeWorkflow",
+  "typeVersion": 1.2,
+  "position": [1050, 300],
+  "parameters": {
+    "workflowId": { "__rl": true, "value": "jyfv4zdobvpbmcCo", "mode": "id" },
+    "options": {}
+  }
+}
+```
+
+**Activation order:** the sub-workflow must be active BEFORE the parent is saved with the reference, otherwise deploy fails with `Cannot publish workflow: Node X references workflow Y which is not published`.
 
 ### Merge (`n8n-nodes-base.merge`)
 Combine data from multiple branches.
@@ -343,6 +386,33 @@ Send email via SMTP.
 - **`defineBelow` mode** requires a full `schema` array with `id`, `displayName`, `type`, and boolean flags alongside the `value` object. Missing schema causes "Could not get parameter" errors.
 - **"Column names were updated after the node's setup"** error means headers have trailing spaces or were modified. Re-type headers in the sheet to remove hidden characters.
 - **Update operation (v4.5)** uses `matchingColumns` array in the `columns` parameter, not the old `lookupColumn`/`lookupValue` pattern.
+- **Update returns empty output** on successful write. Downstream nodes receive zero items and do not execute. Set `"alwaysOutputData": true` on any Update node whose output feeds the next step. Example:
+  ```json
+  {
+    "name": "Update Sheet Row",
+    "type": "n8n-nodes-base.googleSheets",
+    "typeVersion": 4.5,
+    "alwaysOutputData": true,
+    "parameters": { "operation": "update", ... }
+  }
+  ```
+- **Filtered read unreliability** — `filtersUI` with `lookupColumn`/`lookupValue` sometimes silently returns zero rows even when the row exists. Reproduced with `sheetName.mode='name' value='Sheet1'`. When this happens, switch to a direct HTTP Request to the Sheets API and filter client-side:
+  ```json
+  {
+    "name": "Read Intake Row",
+    "type": "n8n-nodes-base.httpRequest",
+    "typeVersion": 4.2,
+    "parameters": {
+      "method": "GET",
+      "url": "https://sheets.googleapis.com/v4/spreadsheets/<sheetId>/values/Sheet1",
+      "authentication": "predefinedCredentialType",
+      "nodeCredentialType": "googleSheetsOAuth2Api"
+    },
+    "credentials": { "googleSheetsOAuth2Api": { "id": "<cred>", "name": "Google Sheets" } }
+  }
+  ```
+  Then in a Code node downstream: `var headers = $json.values[0]; var rows = $json.values.slice(1).map(r => Object.fromEntries(headers.map((h,i)=>[h,r[i]])));`
+- **sheetName mode mismatch across sheets** — Employee Directory (`16iyRqjWoeeXLrrcyP6EOGWL8JKutd-rMBuDzvkNtK38`) requires `{mode: 'id', value: 'gid=0'}`. Most other sheets work with `{mode: 'name', value: 'Sheet1'}`. If one mode fails with "Sheet with name X not found", try the other before blaming anything else.
 - **Best practice**: Use a Code node to format data with exact column header keys, then use `autoMapInputData` mode.
 
 ### Google Drive Known Issues
@@ -351,24 +421,103 @@ Send email via SMTP.
 - **Workaround**: Don't use the Google Drive download node for binary files. Serve templates via a webhook "template server" pattern (base64-embedded in a Code node), or use an HTTP Request node with `?alt=media&supportsAllDrives=true`.
 - **Shared drives** require `supportsAllDrives=true` parameter and `driveId` in the options object. Without these, shared drive files return 403.
 
-### Gmail (`n8n-nodes-base.gmail`)
+### Gmail (`n8n-nodes-base.gmail`) — v2.1
+**Canonical PSD-branded config.** Always include `options.appendAttribution: false`. Never set `options.senderName` unless a Google Workspace send-as alias is configured on the credentialed account (otherwise Gmail accepts the message with a SENT label but silently drops delivery).
 
 ```json
 {
-  "name": "Send Gmail",
+  "name": "Send Notification",
   "type": "n8n-nodes-base.gmail",
   "typeVersion": 2.1,
   "position": [750, 300],
   "parameters": {
-    "sendTo": "={{ $json.email }}",
-    "subject": "Notification from PSD",
-    "message": "Your request has been processed."
+    "sendTo": "={{ $json.recipients }}",
+    "subject": "={{ $json.subject }}",
+    "emailType": "html",
+    "message": "={{ $json.emailHtml }}",
+    "options": { "appendAttribution": false }
   },
   "credentials": {
     "gmailOAuth2": { "id": "cred-id", "name": "PSD Gmail" }
   }
 }
 ```
+
+**Multiple recipients:** `sendTo` accepts a comma-separated string (e.g. `"a@x.com, b@x.com"`). No `cc`/`bcc` field on v2.1 — all recipients go in `sendTo`.
+
+### HTTP Request — Documenso envelope create (multipart)
+Canonical shape for creating a Documenso envelope from n8n. The `type: 'DOCUMENT'` field in the payload is REQUIRED; omitting it causes n8n to report `ECONNREFUSED` (n8n misreports Documenso's 400 validation errors with multipart-form-data as TCP connection refused).
+
+```json
+{
+  "name": "Create Documenso Envelope",
+  "type": "n8n-nodes-base.httpRequest",
+  "typeVersion": 4.2,
+  "parameters": {
+    "method": "POST",
+    "url": "=https://documenso.psd401.net/api/v2/envelope/create",
+    "sendHeaders": true,
+    "headerParameters": { "parameters": [
+      { "name": "Authorization", "value": "=api_xxxxxxxxxxxxxxx" }
+    ]},
+    "sendBody": true,
+    "contentType": "multipart-form-data",
+    "bodyParameters": { "parameters": [
+      { "name": "payload", "value": "={{ $json.payload }}" },
+      { "parameterType": "formBinaryData", "name": "files", "inputDataFieldName": "data" }
+    ]},
+    "options": {}
+  }
+}
+```
+
+Payload shape built by the upstream Code node:
+```js
+var payload = {
+  type: 'DOCUMENT',  // REQUIRED — omitting this causes 400 masked as ECONNREFUSED
+  title: envelopeTitle,
+  recipients: [
+    { email: counselorEmail, name: counselorName, role: 'SIGNER', signingOrder: 1, fields: prefilled.concat(sigFields) },
+    { email: 'cc@psd401.net', name: 'CC Name', role: 'CC', signingOrder: 2, fields: [] }
+  ],
+  meta: {
+    subject: envelopeTitle,
+    message: '...',
+    timezone: 'America/Los_Angeles',
+    dateFormat: 'MM/dd/yyyy',
+    distributionMethod: 'EMAIL',
+    signingOrder: 'SEQUENTIAL',
+    typedSignatureEnabled: true,
+    drawSignatureEnabled: true
+  }
+};
+return [{ json: { payload: JSON.stringify(payload) }, binary: $input.first().binary }];
+```
+
+### HTTP Request — Documenso envelope distribute (raw JSON)
+```json
+{
+  "name": "Distribute Envelope",
+  "type": "n8n-nodes-base.httpRequest",
+  "typeVersion": 4.2,
+  "parameters": {
+    "method": "POST",
+    "url": "https://documenso.psd401.net/api/v2/envelope/distribute",
+    "sendHeaders": true,
+    "headerParameters": { "parameters": [
+      { "name": "Authorization", "value": "api_xxxxxxxxxxxxxxx" },
+      { "name": "Content-Type", "value": "application/json" }
+    ]},
+    "sendBody": true,
+    "contentType": "raw",
+    "rawContentType": "application/json",
+    "body": "={\"envelopeId\":\"{{ $json.id }}\"}",
+    "options": {}
+  }
+}
+```
+
+The distribute endpoint is `/api/v2/envelope/distribute` (not `/envelope/{id}/distribute` — that path returns 404).
 
 ## Response Nodes
 

--- a/plugins/psd-productivity/skills/n8n-manager/scripts/rotate_documenso_key.js
+++ b/plugins/psd-productivity/skills/n8n-manager/scripts/rotate_documenso_key.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+
+// Rotate the Documenso API key across every n8n workflow that uses it.
+//
+// Usage:
+//   bun rotate_documenso_key.js <old_key> <new_key>
+//   bun rotate_documenso_key.js --dry-run <old_key> <new_key>
+//
+// What it does:
+//   1. Lists all workflows on the n8n instance
+//   2. For each, fetches live JSON and counts occurrences of <old_key>
+//   3. For workflows with matches: string-replaces old → new in the full JSON,
+//      strips to API-allowed settings, and PUTs back
+//   4. Prints a per-workflow result line
+//
+// Safe to re-run; workflows with zero matches are skipped.
+
+const { n8nFetch, getEditorUrl } = require('./n8n_client.js');
+
+const args = process.argv.slice(2);
+const dryRun = args[0] === '--dry-run';
+if (dryRun) args.shift();
+const [oldKey, newKey] = args;
+
+if (!oldKey || !newKey) {
+  console.error(JSON.stringify({
+    error: 'Usage: bun rotate_documenso_key.js [--dry-run] <old_key> <new_key>'
+  }));
+  process.exit(1);
+}
+
+if (!oldKey.startsWith('api_') || !newKey.startsWith('api_')) {
+  console.error(JSON.stringify({
+    error: 'Both keys must start with "api_" — refusing to do replacements that look unsafe.'
+  }));
+  process.exit(1);
+}
+
+const ALLOWED_SETTINGS = ['executionOrder', 'callerPolicy', 'errorWorkflow'];
+
+function stripSettings(settings) {
+  const out = {};
+  for (const k of ALLOWED_SETTINGS) {
+    if (settings && settings[k] !== undefined) out[k] = settings[k];
+  }
+  return out;
+}
+
+async function main() {
+  const list = await n8nFetch('/workflows');
+  const workflows = list.data || list.workflows || list || [];
+  const results = [];
+
+  for (const w of workflows) {
+    const id = w.id;
+    const name = w.name || '(unnamed)';
+    let live;
+    try { live = await n8nFetch(`/workflows/${id}`); } catch (e) { results.push({ id, name, status: 'fetch_failed', error: e.message }); continue; }
+
+    const json = JSON.stringify(live);
+    const count = (json.match(new RegExp(oldKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    if (count === 0) continue;
+
+    if (dryRun) {
+      results.push({ id, name, status: 'would_update', references: count });
+      continue;
+    }
+
+    const updatedJson = json.split(oldKey).join(newKey);
+    const updated = JSON.parse(updatedJson);
+    const body = {
+      name: updated.name,
+      nodes: updated.nodes,
+      connections: updated.connections,
+      settings: stripSettings(updated.settings),
+    };
+
+    try {
+      await n8nFetch(`/workflows/${id}`, { method: 'PUT', body });
+      results.push({ id, name, status: 'updated', references: count, url: getEditorUrl(id) });
+    } catch (e) {
+      results.push({ id, name, status: 'update_failed', references: count, error: e.message });
+    }
+  }
+
+  console.log(JSON.stringify({
+    dryRun,
+    totalWorkflows: workflows.length,
+    affectedWorkflows: results.length,
+    results,
+  }, null, 2));
+}
+
+main().catch((e) => {
+  console.error(JSON.stringify({ error: e.message }));
+  process.exit(1);
+});

--- a/plugins/psd-productivity/skills/n8n-manager/scripts/rotate_documenso_key.js
+++ b/plugins/psd-productivity/skills/n8n-manager/scripts/rotate_documenso_key.js
@@ -7,15 +7,15 @@
 //   bun rotate_documenso_key.js --dry-run <old_key> <new_key>
 //
 // What it does:
-//   1. Lists all workflows on the n8n instance
+//   1. Lists all workflows on the n8n instance (paginated via n8nFetchAll)
 //   2. For each, fetches live JSON and counts occurrences of <old_key>
 //   3. For workflows with matches: string-replaces old → new in the full JSON,
-//      strips to API-allowed settings, and PUTs back
-//   4. Prints a per-workflow result line
+//      strips only read-only fields (id, createdAt, etc.), and PUTs back
+//   4. Prints a per-workflow result line (exits non-zero if any update fails)
 //
 // Safe to re-run; workflows with zero matches are skipped.
 
-const { n8nFetch, getEditorUrl } = require('./n8n_client.js');
+const { n8nFetch, n8nFetchAll, getEditorUrl } = require('./n8n_client.js');
 
 const args = process.argv.slice(2);
 const dryRun = args[0] === '--dry-run';
@@ -36,26 +36,31 @@ if (!oldKey.startsWith('api_') || !newKey.startsWith('api_')) {
   process.exit(1);
 }
 
-const ALLOWED_SETTINGS = ['executionOrder', 'callerPolicy', 'errorWorkflow'];
-
-function stripSettings(settings) {
-  const out = {};
-  for (const k of ALLOWED_SETTINGS) {
-    if (settings && settings[k] !== undefined) out[k] = settings[k];
-  }
-  return out;
-}
+// Read-only fields returned by GET that the PUT endpoint rejects.
+const READ_ONLY_FIELDS = ['id', 'createdAt', 'updatedAt', 'versionId'];
 
 async function main() {
-  const list = await n8nFetch('/workflows');
-  const workflows = list.data || list.workflows || list || [];
+  // Use n8nFetchAll to paginate through all workflows (n8nFetch only returns one page)
+  const list = await n8nFetchAll('/workflows');
+  if (list.error) {
+    console.error(JSON.stringify({ error: `Failed to list workflows: ${list.error}` }));
+    process.exit(1);
+  }
+  const workflows = list.data || [];
   const results = [];
+  let hasFailures = false;
 
   for (const w of workflows) {
     const id = w.id;
     const name = w.name || '(unnamed)';
-    let live;
-    try { live = await n8nFetch(`/workflows/${id}`); } catch (e) { results.push({ id, name, status: 'fetch_failed', error: e.message }); continue; }
+
+    // Fetch the full live workflow — n8nFetch returns {error} on failure, does not throw
+    const live = await n8nFetch(`/workflows/${id}`);
+    if (live.error) {
+      results.push({ id, name, status: 'fetch_failed', error: live.error });
+      hasFailures = true;
+      continue;
+    }
 
     const json = JSON.stringify(live);
     const count = (json.match(new RegExp(oldKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
@@ -66,20 +71,22 @@ async function main() {
       continue;
     }
 
+    // Replace key in the full workflow JSON, then strip only read-only fields
+    // that the API rejects on PUT. This preserves all workflow metadata (tags,
+    // active, staticData, pinData, settings, etc.) instead of destructively
+    // rebuilding a partial body.
     const updatedJson = json.split(oldKey).join(newKey);
     const updated = JSON.parse(updatedJson);
-    const body = {
-      name: updated.name,
-      nodes: updated.nodes,
-      connections: updated.connections,
-      settings: stripSettings(updated.settings),
-    };
+    for (const field of READ_ONLY_FIELDS) {
+      delete updated[field];
+    }
 
-    try {
-      await n8nFetch(`/workflows/${id}`, { method: 'PUT', body });
+    const putResult = await n8nFetch(`/workflows/${id}`, { method: 'PUT', body: updated });
+    if (putResult.error) {
+      results.push({ id, name, status: 'update_failed', references: count, error: putResult.error });
+      hasFailures = true;
+    } else {
       results.push({ id, name, status: 'updated', references: count, url: getEditorUrl(id) });
-    } catch (e) {
-      results.push({ id, name, status: 'update_failed', references: count, error: e.message });
     }
   }
 
@@ -89,6 +96,8 @@ async function main() {
     affectedWorkflows: results.length,
     results,
   }, null, 2));
+
+  if (hasFailures) process.exit(1);
 }
 
 main().catch((e) => {

--- a/plugins/psd-productivity/skills/pdf-builder/SKILL.md
+++ b/plugins/psd-productivity/skills/pdf-builder/SKILL.md
@@ -129,7 +129,7 @@ For documents that don't fit a template, build a JSON spec with sections:
 |------|-------------|----------------|
 | `heading` | Josefin Sans Bold title | `text`, `level` (1=18pt, 2=14pt, 3=11pt) |
 | `paragraph` | Inter Regular body text (auto-wrapped) | `text`, `fontSize`, `lineHeight` |
-| `field_row` | Horizontal row of labeled input boxes | `fields[]` with `label`, `type`, `width` (0-1 fraction), `value`, `height` (points, default 22) |
+| `field_row` | Horizontal row of labeled input boxes | `fields[]` with `label`, `type`, `width` (0-1 fraction), `value`, `height` (points, default 22). Section-level options: `showLabels` (bool, default `true`), `gap` (int, default ~9pt — horizontal gap between cells), `rowGap` (int, default ~9pt — vertical gap after the row) |
 | `checkbox_group` | Vertical checkbox list | `label`, `items[]` with `label`, `checked`, `required` |
 | `table` | Data table with alternating rows | `headers[]`, `rows[][]` |
 | `signature_block` | Signing zone with role labels | `signers[]` with `role`, `fields[]`, `anchor` ("flow" or "bottom") |
@@ -139,6 +139,42 @@ For documents that don't fit a template, build a JSON spec with sections:
 **CRITICAL — Duplicate field labels**: Field labels are slugified to create manifest field names. Two fields with the same label (e.g., both "Position") produce the same slug, causing the manifest `positions` object to only keep the last one. Use unique labels (e.g., "Team Member Position", "Evaluator Position") or deduplicate manually in downstream code.
 
 **Spacer for page breaks**: A spacer of ~80pt after a signature block reliably pushes the next section to a new page. Use this to separate reference appendices from the evaluation content.
+
+### Building a tight table of form fields
+
+Use `showLabels: false`, `gap: 0`, `rowGap: 0` on stacked `field_row` sections to render a proper table of fillable cells (one header row with labels, many flush data rows below). Each cell still needs a unique label for slug uniqueness — compact names like `S2 First` / `S2 Last` work well.
+
+```json
+{ "type": "field_row", "gap": 0, "rowGap": 0, "fields": [
+    { "label": "First Name", "type": "TEXT", "width": 0.18, "height": 14 },
+    { "label": "Last Name",  "type": "TEXT", "width": 0.18, "height": 14 },
+    { "label": "Student ID", "type": "TEXT", "width": 0.13, "height": 14 },
+    { "label": "DOB",        "type": "TEXT", "width": 0.15, "height": 14 },
+    { "label": "Grade",      "type": "TEXT", "width": 0.10, "height": 14 },
+    { "label": "School",     "type": "TEXT", "width": 0.26, "height": 14 }
+]},
+{ "type": "field_row", "showLabels": false, "gap": 0, "rowGap": 0, "fields": [
+    { "label": "S2 First", "type": "TEXT", "width": 0.18, "height": 14 },
+    { "label": "S2 Last",  "type": "TEXT", "width": 0.18, "height": 14 },
+    { "label": "S2 ID",    "type": "TEXT", "width": 0.13, "height": 14 },
+    { "label": "S2 DOB",   "type": "TEXT", "width": 0.15, "height": 14 },
+    { "label": "S2 Grade", "type": "TEXT", "width": 0.10, "height": 14 },
+    { "label": "S2 School","type": "TEXT", "width": 0.26, "height": 14 }
+]},
+...
+```
+
+Reference implementation: `workflows/ssd-mv-intake/template-spec.json` in the `psd-workflow-automation` repo (6-student McKinney-Vento intake table).
+
+### Page 1 title rendering
+
+The letterhead module only renders the spec's top-level `title` in the **continuation header** on pages 2+. Page 1 has the logo block and letterhead but no title bar. To show the document title on page 1, add an explicit `heading` section at the top of `sections`:
+
+```json
+{ "type": "spacer", "height": 4 },
+{ "type": "heading", "text": "Annual McKinney-Vento Intake Form", "level": 1 },
+{ "type": "spacer", "height": 6 },
+```
 
 ### Field Types for `field_row` and `signature_block`
 

--- a/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
+++ b/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
@@ -164,12 +164,22 @@ class PDFBuilder:
         return y - 8
 
     def _draw_field_row(self, c, area, y, section):
-        """Draw a row of labeled input boxes. Returns new y position."""
+        """Draw a row of labeled input boxes. Returns new y position.
+
+        Options:
+          showLabels: bool (default True) — render labels above fields
+          rowGap: int (default FIELD_GAP) — vertical gap after the row
+          gap: int (default FIELD_GAP) — horizontal gap between fields
+        """
         fields = section.get("fields", [])
         if not fields:
             return y
 
-        total_gap = FIELD_GAP * (len(fields) - 1)
+        show_labels = section.get("showLabels", True)
+        h_gap = section.get("gap", FIELD_GAP)
+        row_gap = section.get("rowGap", FIELD_GAP)
+
+        total_gap = h_gap * (len(fields) - 1)
         total_width = area["width"] - total_gap
         x = area["x"]
 
@@ -183,18 +193,20 @@ class PDFBuilder:
         # For the row layout, use the tallest field's height
         row_height = max(f.get("height", FIELD_BOX_HEIGHT) for f in fields)
 
-        # Move down: label height + box height + padding
-        y -= (FIELD_LABEL_SIZE + row_height + 6)
+        # Move down: label height (if shown) + box height + padding
+        label_reserve = (FIELD_LABEL_SIZE + 4) if show_labels else 0
+        y -= (label_reserve + row_height + 2)
 
         # y is now at the bottom of the field box
         box_y = y
         for i, (field, fw) in enumerate(zip(fields, field_widths)):
             fh = field.get("height", FIELD_BOX_HEIGHT)
 
-            # Label above the box
-            c.setFont("Inter", FIELD_LABEL_SIZE)
-            c.setFillColor(PACIFIC)
-            c.drawString(x, box_y + fh + 3, field.get("label", ""))
+            # Label above the box (optional)
+            if show_labels:
+                c.setFont("Inter", FIELD_LABEL_SIZE)
+                c.setFillColor(PACIFIC)
+                c.drawString(x, box_y + fh + 3, field.get("label", ""))
 
             # Draw input box
             c.setStrokeColor(LIGHT_GRAY)
@@ -219,9 +231,9 @@ class PDFBuilder:
                 placeholder=field.get("placeholder", ""),
             )
 
-            x += fw + FIELD_GAP
+            x += fw + h_gap
 
-        return box_y - FIELD_GAP
+        return box_y - row_gap
 
     def _draw_checkbox_group(self, c, area, y, section):
         """Draw a vertical list of checkboxes. Returns new y position."""

--- a/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
+++ b/plugins/psd-productivity/skills/pdf-builder/scripts/generate_pdf.py
@@ -195,7 +195,7 @@ class PDFBuilder:
 
         # Move down: label height (if shown) + box height + padding
         label_reserve = (FIELD_LABEL_SIZE + 4) if show_labels else 0
-        y -= (label_reserve + row_height + 2)
+        y -= (label_reserve + row_height)
 
         # y is now at the bottom of the field box
         box_y = y


### PR DESCRIPTION
## Summary
Cumulative documentation + tooling updates to the n8n-manager, documenso-manager, and pdf-builder skills, all derived from real bugs we hit during the 2026-04-20 → 2026-04-22 McKinney-Vento DocuSign-to-Documenso migration build. Goal: prevent the trial-and-error cycles from repeating.

## What changed

### `n8n-manager`
- **SKILL.md**: 12 new Key Technical Warnings (Sheets Update empty output, Sheets filter unreliability, Switch v3.2 silent routing, executeWorkflow v1.0 broken, Gmail senderName drops, n8n masks Documenso 400 as ECONNREFUSED, etc.)
- **n8n-node-catalog.md**: canonical full-shape JSON snippets for Switch v3.2, executeWorkflow v1.2, Google Sheets Update with `alwaysOutputData`, Sheets filter-read fallback to direct API, Gmail v2.1 (no senderName, appendAttribution false), HTTP Request for Documenso `create` (multipart) and `distribute` (raw JSON) endpoints
- **NEW: documenso-n8n-patterns.md**: end-to-end patterns for submission workflow, completion handler, and document completion router. Title-prefix routing convention. "Common debug flow when nothing happens" runbook
- **NEW: scripts/rotate_documenso_key.js**: rotates the Documenso API key across every workflow that references it. `--dry-run` mode for safety

### `documenso-manager`
- **SKILL.md**: 8 new warnings (distribute endpoint shape, type:'DOCUMENT' requirement, billing-enabled cap, team-scoped keys, per-team webhooks, envelope id canonicalization, SMTP delivery bypass, CC behavior)
- **documenso-api-reference.md**: explicit `/envelope/create` and `/envelope/distribute` shapes with curl examples; envelope ID canonicalization table
- **NEW: documenso-self-hosting-ops.md**: billing-enabled trap with code reference, team API key rotation, webhook setup per-team, SMTP delivery diagnostics, full error→cause cheatsheet

### `pdf-builder`
- **SKILL.md**: documents new `field_row` section options (`showLabels`, `gap`, `rowGap`) — pairs with #41. Adds "Building a tight table of form fields" pattern. Adds "Page 1 title rendering" note (letterhead only adds title to continuation header)

## Why this matters
During the MV intake build we burned hours on:
- "Service refused the connection" → was a Documenso 400 from missing `type: 'DOCUMENT'`
- Switch routing always going to output 0 → was missing `combinator: 'and'` + `operator.name`
- Sub-workflow "Workflow does not exist" → was executeWorkflow typeVersion 1.0
- Completion email never delivered → was Gmail node `senderName` without Workspace alias
- Sheet row updates not flowing downstream → was Sheets Update returning empty without `alwaysOutputData`

Every one of these was already a single-flag-or-property fix. This PR captures every one in the skill docs so future builds catch them in seconds, not hours.

## Test plan
- [x] All edits are additive (no existing snippets removed)
- [x] New rotation script runnable with `--dry-run` (verified payload structure parses)
- [x] New reference files cross-link from their respective SKILL.md "Reference Documents" tables
- [x] No CLI command names changed (`/n8n` and `/documenso` slash-commands unaffected)
- [ ] Squash before merge if you prefer single-commit history

## Related
- #41 (pdf-builder field_row options — the code change this PR documents)