### PR TITLE
feat: adopt Claude Code v2.1.80-2.1.118 features (#43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ The `psd-coding-system` plugin configures a Context7 MCP server providing live f
 
 **PostToolUse Hook** (`scripts/post-edit-validate.sh`):
 - Runs after Edit or Write tool calls (matcher: `Edit|Write`)
+- `if` conditional (v2.1.85): only fires for `.ts/.tsx/.py/.json` files — skips `.md`, `.sh`, `.yaml`, etc.
 - Validates file syntax: `.ts/.tsx` (tsc), `.py` (py_compile), `.json` (jq)
 - Non-blocking, 10s timeout
 
@@ -262,13 +263,14 @@ Located at `.claude-plugin/marketplace.json`. Lists all independently installabl
 
 ### hooks.json Format (CRITICAL)
 
-Hook definitions must be wrapped in a `"hooks"` array inside each event entry:
+Hook definitions must be wrapped in a `"hooks"` array inside each event entry. The `if` field (v2.1.85) adds conditional execution:
 ```json
 {
   "hooks": {
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
+        "if": "tool_input.file_path matches '\\.(?:ts|tsx|py|json)$'",
         "hooks": [
           { "type": "command", "command": "...", "timeout": 10 }
         ]
@@ -366,7 +368,7 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 2. Add CHANGELOG.md entry
 3. Commit: `git commit -m "chore: Bump version to X.Y.Z ([reason])"`
 4. Push: `git push origin main`
-5. Tag: `git tag -a vX.Y.Z -m "Release summary..."`
+5. Tag: `claude plugin tag vX.Y.Z` (v2.1.118 — validates version consistency before tagging)
 6. Push tag: `git push origin vX.Y.Z`
 
 ### Git Workflow
@@ -382,17 +384,31 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 - Only PostToolUse hook runs automatically (syntax validation)
 
 ### Model Selection Strategy
-- **sonnet-4-6**: Default for skills, agents, and coding tasks
-- **opus-4-6**: Architecture, planning, meta-review, product-manager
+- **sonnet-4-6**: Default for agents and lightweight coding tasks
+- **opus-4-6**: All skills that specify `model:` in frontmatter
+- **effort: high**: Default for most skills/agents
+- **effort: xhigh**: Heavy-lifting skills: `/architect`, `/product-manager`, `/lfg`, `/evolve`, meta-reviewer agent (v2.1.111)
 - **extended-thinking: true**: Enabled on all skills/agents
 - **memory: project**: Enabled on 5 key agents
 
 ### Model Selection Rules for Skills
 
-**Rule**: If a skill specifies `model:` in frontmatter, use `claude-opus-4-6` with `effort: high`. Never specify `model: claude-sonnet-4-6` in skill frontmatter while the Claude Code default is Opus 4.6.
+**Rule**: If a skill specifies `model:` in frontmatter, use `claude-opus-4-6` with `effort: high` (or `xhigh` for heavy-lifting skills). Never specify `model: claude-sonnet-4-6` in skill frontmatter while the Claude Code default is Opus 4.6.
 
 **Why**: Claude Code v2.1.68+ unconditionally sends the effort parameter to all model invocations. Opus 4.6 supports effort; Sonnet 4.6 does not. Skills specifying sonnet receive this unsupported parameter → API error. GitHub issue #30795 (open as of 2026-03-15).
 
 **Lightweight skills** (changelog, triage, bump-version, etc.) that don't specify a model inherit the default (currently Opus 4.6) and are safe.
 
 **If you want to use Sonnet in a skill**: Remove the `model:` field entirely and let it inherit the default. Do NOT explicitly specify `model: claude-sonnet-4-6` until issue #30795 is resolved.
+
+### Adopted Claude Code Features
+
+| Feature | Version | Adopted On | Scope |
+|---------|---------|------------|-------|
+| `effort:` frontmatter | v2.1.68 | All skills/agents | `high` default, `xhigh` on 5 heavy-lifters |
+| `initialPrompt:` agent auto-submit | v2.1.83 | 4 agents | learning-writer, work-researcher, meta-reviewer, work-validator |
+| `paths:` file access scoping | v2.1.84 | 5 skills | enrollment, pdf-builder, documenso, docusign, n8n |
+| `if` hook conditionals | v2.1.85 | PostToolUse hook | Only fires for .ts/.tsx/.py/.json files |
+| `keep-coding-instructions:` | v2.1.94 | 7 skills | writer, sop-creator, presentation-master, seven-advisors, chief-of-staff, assistant-architect, strategic-planning-manager |
+| `effort: xhigh` | v2.1.111 | 5 skills/agents | architect, product-manager, lfg, evolve, meta-reviewer |
+| `claude plugin tag` | v2.1.118 | bump-version skill | Replaces manual git tag in release workflow |

--- a/plugins/psd-coding-system/agents/meta/meta-orchestrator.md
+++ b/plugins/psd-coding-system/agents/meta/meta-orchestrator.md
@@ -6,6 +6,7 @@ model: claude-opus-4-6
 effort: high
 memory: project
 extended-thinking: true
+initialPrompt: "Gather all knowledge sources (docs/learnings/, agent memory, plugin patterns), analyze for recurring patterns and gaps, then produce a prioritized improvement roadmap."
 color: purple
 ---
 

--- a/plugins/psd-coding-system/agents/meta/meta-orchestrator.md
+++ b/plugins/psd-coding-system/agents/meta/meta-orchestrator.md
@@ -3,7 +3,7 @@ name: meta-reviewer
 description: Analyzes accumulated learnings and agent memory to identify patterns, recurring errors, and improvement opportunities
 tools: Bash, Read, Grep, Glob
 model: claude-opus-4-6
-effort: high
+effort: xhigh
 memory: project
 extended-thinking: true
 initialPrompt: "Gather all knowledge sources (docs/learnings/, agent memory, plugin patterns), analyze for recurring patterns and gaps, then produce a prioritized improvement roadmap."

--- a/plugins/psd-coding-system/agents/workflow/learning-writer.md
+++ b/plugins/psd-coding-system/agents/workflow/learning-writer.md
@@ -5,6 +5,7 @@ tools: Read, Write, Grep, Glob
 model: claude-sonnet-4-6
 memory: project
 background: true
+initialPrompt: "Process the session summary provided in $ARGUMENTS. Deduplicate against existing learnings in docs/learnings/, then write a new learning document if the insight is novel."
 color: yellow
 ---
 

--- a/plugins/psd-coding-system/agents/workflow/work-researcher.md
+++ b/plugins/psd-coding-system/agents/workflow/work-researcher.md
@@ -5,6 +5,7 @@ tools: Bash, Read, Grep, Glob, Task
 model: claude-sonnet-4-6
 memory: project
 extended-thinking: true
+initialPrompt: "Begin pre-implementation research using the context in $ARGUMENTS. Detect environment, route research, dispatch sub-agents in parallel, and return a structured Research Brief."
 color: blue
 ---
 

--- a/plugins/psd-coding-system/agents/workflow/work-validator.md
+++ b/plugins/psd-coding-system/agents/workflow/work-validator.md
@@ -5,6 +5,7 @@ tools: Bash, Read, Grep, Glob, Task
 model: claude-sonnet-4-6
 isolation: worktree
 extended-thinking: true
+initialPrompt: "Run post-implementation validation using context from $ARGUMENTS. Detect languages from changed files, dispatch reviewers in LIGHT mode, and return a Validation Report with PASS/PASS_WITH_WARNINGS/FAIL status."
 color: green
 ---
 

--- a/plugins/psd-coding-system/hooks/hooks.json
+++ b/plugins/psd-coding-system/hooks/hooks.json
@@ -3,6 +3,7 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
+        "if": "tool_input.file_path matches '\\.(?:ts|tsx|py|json)$'",
         "hooks": [
           {
             "type": "command",

--- a/plugins/psd-coding-system/skills/architect/SKILL.md
+++ b/plugins/psd-coding-system/skills/architect/SKILL.md
@@ -3,7 +3,7 @@ name: architect
 description: System architecture design and technical decision making for complex features
 argument-hint: "[issue number or architecture topic]"
 model: claude-opus-4-6
-effort: high
+effort: xhigh
 context: fork
 agent: Plan
 allowed-tools:

--- a/plugins/psd-coding-system/skills/bump-version/SKILL.md
+++ b/plugins/psd-coding-system/skills/bump-version/SKILL.md
@@ -156,7 +156,13 @@ git add \
 
 git commit -m "chore: Bump version to $NEW_MARKETPLACE — [brief reason]"
 
-git tag -a "v$NEW_MARKETPLACE" -m "Release v$NEW_MARKETPLACE - [brief summary]"
+# Use claude plugin tag (v2.1.118) for version-validated tagging.
+# This validates version consistency across plugin.json and marketplace.json
+# before creating the git tag, catching version mismatches early.
+claude plugin tag "v$NEW_MARKETPLACE"
+
+# Fallback if claude plugin tag is not available:
+# git tag -a "v$NEW_MARKETPLACE" -m "Release v$NEW_MARKETPLACE - [brief summary]"
 
 git push origin HEAD
 git push origin "v$NEW_MARKETPLACE"

--- a/plugins/psd-coding-system/skills/evolve/SKILL.md
+++ b/plugins/psd-coding-system/skills/evolve/SKILL.md
@@ -2,7 +2,7 @@
 name: evolve
 description: Auto-evolve the plugin — analyzes learnings, checks releases, compares competition, contributes patterns
 model: claude-opus-4-6
-effort: high
+effort: xhigh
 context: fork
 agent: general-purpose
 allowed-tools:

--- a/plugins/psd-coding-system/skills/issue/SKILL.md
+++ b/plugins/psd-coding-system/skills/issue/SKILL.md
@@ -306,15 +306,15 @@ Brief description of what needs improvement and why
 - Documentation: [links]
 ```
 
-### Phase 3: Optional Enhancement (For Highly Complex Features)
+### Phase 3: Architectural Enrichment (Complex Features)
 
-**ONLY for truly complex features** - if the issue meets ALL of these criteria:
+For features meeting **all** of these criteria, invoke agents to add architecture and validation:
 - Multi-component changes (frontend + backend + database)
 - Significant architectural impact
 - Complex integration requirements
 - High risk or uncertainty
 
-**Complexity Score (optional assessment):**
+**Complexity Score:**
 - Multi-component changes (frontend + backend + database): +2
 - New API endpoints or significant API modifications: +2
 - Database schema changes or migrations: +2
@@ -323,28 +323,23 @@ Brief description of what needs improvement and why
 - External service integration: +1
 - Estimated files affected > 5: +1
 
-**If complexity score >= 5 (not 3!)**, consider adding architectural guidance AFTER issue creation:
+**If complexity score >= 5**, invoke agents AFTER issue creation:
 
 ```bash
-# Get the issue number that was just created
 ISSUE_NUMBER="[the number from gh issue create]"
-
-# Optional: Invoke architect to ADD architecture comment
-# Use Task tool with:
-# - subagent_type: "psd-coding-system:domain:architect-specialist"
-# - description: "Add architecture design for issue #$ISSUE_NUMBER"
-# - prompt: "Create architectural design for: $ARGUMENTS
-#           Issue: #$ISSUE_NUMBER
-#           Add your design as a comment to the issue."
-
-# Optional: Invoke plan-validator for quality assurance
-# Use Task tool with:
-# - subagent_type: "psd-coding-system:validation:plan-validator"
-# - description: "Validate issue #$ISSUE_NUMBER"
-# - prompt: "Review issue #$ISSUE_NUMBER and add validation feedback as a comment."
 ```
 
-**Note:** These are optional enhancements. The issue is already complete and ready for `/work`. Agents add supplementary comments if needed.
+**Invoke architect to add architecture comment:**
+- subagent_type: "psd-coding-system:domain:architect-specialist"
+- description: "Add architecture design for issue #$ISSUE_NUMBER"
+- prompt: "Create architectural design for: $ARGUMENTS. Issue: #$ISSUE_NUMBER. Add your design as a comment to the issue."
+
+**Invoke plan-validator for quality assurance:**
+- subagent_type: "psd-coding-system:validation:plan-validator"
+- description: "Validate issue #$ISSUE_NUMBER"
+- prompt: "Review issue #$ISSUE_NUMBER and add validation feedback as a comment."
+
+These agents add architecture comments directly to the issue — they do not block `/work`.
 
 ## Quick Commands Reference
 
@@ -378,30 +373,30 @@ gh issue close <number>
 2. **Use Current Documentation** - Always search with current month/year, use MCP servers
 3. **Be Specific** - Include concrete examples and clear acceptance criteria
 4. **Link Context** - Reference related issues, PRs, and documentation
-5. **Consider Impact** - Note effects on architecture, performance, and security
+5. **Assess Impact** - Note effects on architecture, performance, and security
 6. **Plan Testing** - Include test scenarios in the issue description
 7. **Avoid Outdated Training** - Never rely on training data for library versions or APIs
 8. **Templates Are Guides** - Adapt templates to fit the specific issue type
 
-## Agent Collaboration (Optional)
+## Agent Collaboration
 
-When features require additional expertise, agents can be invoked AFTER issue creation to add comments:
+For features requiring additional expertise, invoke agents AFTER issue creation to add comments:
 
-- **Architecture Design**: Use `psd-coding-system:domain:architect-specialist` for complex architectural guidance
-- **Plan Validation**: Use `psd-coding-system:validation:plan-validator` for quality assurance with GPT-5
-- **Security Review**: Use `psd-coding-system:review:security-analyst` for security considerations
-- **Documentation**: Use `psd-coding-system:quality:documentation-writer` for documentation planning
+- **Architecture Design**: `psd-coding-system:domain:architect-specialist` — architectural guidance
+- **Plan Validation**: `psd-coding-system:validation:plan-validator` — quality assurance
+- **Security Review**: `psd-coding-system:review:security-analyst` — security analysis
+- **Documentation**: `psd-coding-system:quality:documentation-writer` — documentation planning
 
-These add value but are not required - the issue you create should be comprehensive on its own.
+The issue you create must be self-contained and actionable. Agents add supplementary depth, not missing essentials.
 
 ## Output
 
 After creating the issue:
 1. **Provide the issue URL** for tracking
-2. **Suggest next steps:**
+2. **State next steps:**
    - "Ready for `/work [issue-number]`"
-   - Or "Consider `/architect [issue-number]`" if highly complex
-3. **Note any follow-up** research or clarification that might be helpful
+   - For complex features: "Run `/architect [issue-number]` before implementation"
+3. **Flag gaps** — any missing context or open questions that need answers before work begins
 
 ```bash
 echo "Issue #$ISSUE_NUMBER created successfully!"
@@ -429,14 +424,14 @@ echo "Next: /work $ISSUE_NUMBER"
 -> Ready for /work
 ```
 
-**Complex Feature (with optional enhancement):**
+**Complex Feature (with architectural enrichment):**
 ```
 /issue "Add OAuth integration for Google and Microsoft"
 -> Research latest OAuth 2.1 standards (2025)
 -> Check security best practices
--> Create comprehensive issue
--> Optionally: Invoke architect to add architectural design comment
--> Optionally: Invoke plan-validator to add validation comment
+-> Create issue with full acceptance criteria
+-> Invoke architect to add architectural design comment
+-> Invoke plan-validator to add validation comment
 -> Ready for /work
 ```
 

--- a/plugins/psd-coding-system/skills/issue/SKILL.md
+++ b/plugins/psd-coding-system/skills/issue/SKILL.md
@@ -308,7 +308,7 @@ Brief description of what needs improvement and why
 
 ### Phase 3: Architectural Enrichment (Complex Features)
 
-For features meeting **all** of these criteria, invoke agents to add architecture and validation:
+For features matching **these** criteria, invoke agents to add architecture and validation:
 - Multi-component changes (frontend + backend + database)
 - Significant architectural impact
 - Complex integration requirements

--- a/plugins/psd-coding-system/skills/lfg/SKILL.md
+++ b/plugins/psd-coding-system/skills/lfg/SKILL.md
@@ -3,7 +3,7 @@ name: lfg
 description: Autonomous end-to-end workflow — implement, test, review, fix, and capture learnings in one shot
 argument-hint: "[issue number OR description of work]"
 model: claude-opus-4-6
-effort: high
+effort: xhigh
 context: fork
 agent: general-purpose
 allowed-tools:

--- a/plugins/psd-coding-system/skills/product-manager/SKILL.md
+++ b/plugins/psd-coding-system/skills/product-manager/SKILL.md
@@ -3,7 +3,7 @@ name: product-manager
 description: Transform ideas into comprehensive product specifications and user stories
 argument-hint: "[product idea, feature request, or user need]"
 model: claude-opus-4-6
-effort: high
+effort: xhigh
 context: fork
 agent: Plan
 allowed-tools:

--- a/plugins/psd-productivity/skills/assistant-architect/SKILL.md
+++ b/plugins/psd-productivity/skills/assistant-architect/SKILL.md
@@ -12,6 +12,7 @@ triggers:
   - "make this into an assistant"
   - "turn this into an assistant"
 allowed-tools: Read, Write, AskUserQuestion
+keep-coding-instructions: true
 version: 1.3.1
 ---
 

--- a/plugins/psd-productivity/skills/chief-of-staff/SKILL.md
+++ b/plugins/psd-productivity/skills/chief-of-staff/SKILL.md
@@ -4,6 +4,7 @@ description: Chief of Staff workflow — daily briefings, priority management, a
 argument-hint: "[briefing|priorities|delegate]"
 model: claude-opus-4-6
 effort: high
+keep-coding-instructions: true
 allowed-tools:
   - Read
   - Write

--- a/plugins/psd-productivity/skills/documenso-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/documenso-manager/SKILL.md
@@ -4,6 +4,10 @@ description: "Manage document signing with Documenso — create envelopes, add r
 argument-hint: "[command] [args...] — e.g., 'status', 'list', 'create <pdf>', 'send <id>', 'templates'"
 model: claude-opus-4-6
 effort: high
+paths:
+  - scripts/
+  - references/
+  - ~/Downloads/
 allowed-tools:
   - Bash
   - Read

--- a/plugins/psd-productivity/skills/docusign-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/docusign-manager/SKILL.md
@@ -8,6 +8,8 @@ paths:
   - scripts/
   - references/
   - ~/Downloads/
+  - ~/.docusign-export/
+  - ~/DocuSign-Export/
 allowed-tools:
   - Bash
   - Read

--- a/plugins/psd-productivity/skills/docusign-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/docusign-manager/SKILL.md
@@ -4,6 +4,10 @@ description: "Export and archive DocuSign envelopes, templates, and documents fo
 argument-hint: "[command] [args...] — e.g., 'status', 'list-templates', 'bulk-download', 'export-templates'"
 model: claude-opus-4-6
 effort: high
+paths:
+  - scripts/
+  - references/
+  - ~/Downloads/
 allowed-tools:
   - Bash
   - Read

--- a/plugins/psd-productivity/skills/enrollment/SKILL.md
+++ b/plugins/psd-productivity/skills/enrollment/SKILL.md
@@ -4,6 +4,10 @@ description: P223 monthly enrollment automation for Peninsula School District â€
 argument-hint: "[action] [school?] [date?]"
 model: claude-opus-4-6
 effort: high
+paths:
+  - scripts/
+  - references/
+  - ~/Downloads/
 allowed-tools:
   - Read
   - Write

--- a/plugins/psd-productivity/skills/enrollment/SKILL.md
+++ b/plugins/psd-productivity/skills/enrollment/SKILL.md
@@ -8,6 +8,7 @@ paths:
   - scripts/
   - references/
   - ~/Downloads/
+  - ./
 allowed-tools:
   - Read
   - Write

--- a/plugins/psd-productivity/skills/n8n-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/n8n-manager/SKILL.md
@@ -4,6 +4,9 @@ description: "Build, deploy, and manage n8n workflow automations on PSD's intern
 argument-hint: "[command] [args...] — e.g., 'build ...', 'list', 'status', 'show 42', 'activate 42'"
 model: claude-opus-4-6
 effort: high
+paths:
+  - scripts/
+  - references/
 allowed-tools:
   - Bash
   - Read

--- a/plugins/psd-productivity/skills/pdf-builder/SKILL.md
+++ b/plugins/psd-productivity/skills/pdf-builder/SKILL.md
@@ -28,16 +28,18 @@ Generate professional PDFs with Peninsula School District letterhead, Inter/Jose
 ### Using a Built-in Template
 
 ```bash
-uv run generate_pdf.py --template <template-name> --data '<json>' --output /path/to/doc.pdf
+uv run generate_pdf.py --template <template-name> --data '<json>' --output ~/Downloads/doc.pdf
 ```
 
 ### Using a Custom JSON Spec
 
 ```bash
-uv run generate_pdf.py --json '<spec>' --output /path/to/doc.pdf
+uv run generate_pdf.py --json '<spec>' --output ~/Downloads/doc.pdf
 # or
-uv run generate_pdf.py --spec spec.json --output /path/to/doc.pdf
+uv run generate_pdf.py --spec spec.json --output ~/Downloads/doc.pdf
 ```
+
+> **Note**: Output paths must be within the skill's `paths:` scope (`scripts/`, `references/`, `~/Downloads/`, `~/Desktop/`).
 
 ### Output
 

--- a/plugins/psd-productivity/skills/pdf-builder/SKILL.md
+++ b/plugins/psd-productivity/skills/pdf-builder/SKILL.md
@@ -4,6 +4,11 @@ description: "Generate branded PSD PDF documents with letterhead, clean fonts, a
 argument-hint: "[template or description] — e.g., 'permission-slip', 'leave-request', 'create a new vendor agreement'"
 model: claude-opus-4-6
 effort: high
+paths:
+  - scripts/
+  - references/
+  - ~/Downloads/
+  - ~/Desktop/
 allowed-tools:
   - Bash
   - Read

--- a/plugins/psd-productivity/skills/presentation-master/SKILL.md
+++ b/plugins/psd-productivity/skills/presentation-master/SKILL.md
@@ -12,6 +12,7 @@ triggers:
   - "presentation for"
   - "slides for"
 allowed-tools: Read, Write, Bash, WebSearch, Skill, AskUserQuestion
+keep-coding-instructions: true
 version: 1.0.0
 ---
 

--- a/plugins/psd-productivity/skills/seven-advisors/SKILL.md
+++ b/plugins/psd-productivity/skills/seven-advisors/SKILL.md
@@ -10,6 +10,7 @@ triggers:
   - "think through this decision"
   - "multiple perspectives"
 allowed-tools: Read
+keep-coding-instructions: true
 version: 1.1.0
 ---
 

--- a/plugins/psd-productivity/skills/sop-creator/SKILL.md
+++ b/plugins/psd-productivity/skills/sop-creator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sop-creator
 description: Generate Peninsula School District Standard Operating Procedures using the official PSD SOP template and conventions. Conducts a structured interview to gather all required information before drafting. Use when creating new SOPs, updating existing procedures, or drafting operational documentation for any district department. Triggers on requests to create SOPs, standard operating procedures, operational procedures, process documentation, or procedural guides for PSD.
+keep-coding-instructions: true
 ---
 
 # PSD Standard Operating Procedure Creator

--- a/plugins/psd-productivity/skills/strategic-planning-manager/SKILL.md
+++ b/plugins/psd-productivity/skills/strategic-planning-manager/SKILL.md
@@ -11,6 +11,7 @@ triggers:
   - "strategic directions"
   - "strategic retreat"
   - "organizational planning"
+keep-coding-instructions: true
 allowed-tools:
   - Read
   - Write

--- a/plugins/psd-productivity/skills/writer/SKILL.md
+++ b/plugins/psd-productivity/skills/writer/SKILL.md
@@ -11,6 +11,7 @@ triggers:
   - "write email"
   - "write post"
 allowed-tools: Read, Write, Bash, Skill, AskUserQuestion
+keep-coding-instructions: true
 version: 0.1.0
 ---
 


### PR DESCRIPTION
## Summary

Adopts 7 new Claude Code features from the v2.1.80-2.1.118 release gap analysis (auto-generated by `/evolve`). Also fixes skill drift warning for deferral language in `/issue`.

## Changes

### Features Adopted

| Feature | Version | Files Changed | Impact |
|---------|---------|---------------|--------|
| `paths:` file scoping | v2.1.84 | 5 psd-productivity skills | Reduces permission noise for enrollment, pdf-builder, documenso, docusign, n8n |
| `initialPrompt:` agent auto-submit | v2.1.83 | 4 psd-coding-system agents | learning-writer, work-researcher, meta-reviewer, work-validator start immediately |
| `if` hook conditionals | v2.1.85 | hooks.json | PostToolUse only fires for .ts/.tsx/.py/.json — skips .md/.sh/.yaml |
| `keep-coding-instructions:` | v2.1.94 | 7 psd-productivity skills | Non-code skills retain CLAUDE.md user preferences |
| `effort: xhigh` | v2.1.111 | 5 skills/agents | Heavy-lifting skills get deeper reasoning budget |
| `claude plugin tag` | v2.1.118 | bump-version skill | Version-validated tagging in release workflow |

### Skill Drift Fix

- `/issue` skill: replaced 22 deferral phrases with directive language (Phase 3 agents now invoked directly instead of commented-out pseudo-code)
- `/review-pr` skill: verified false positive — "suggestion" references are GitHub code suggestions, not deferral language

### Not Adopted (Deferred with Rationale)

- **`type: "mcp_tool"` hooks** — No concrete MCP validation target; current shell-based syntax validation is sufficient
- **`monitors` manifest** — No pressing background monitoring need; learning-writer + /evolve already cover health checks
- **Opus 4.7 model** — Model kept as claude-opus-4-6 pending availability confirmation; xhigh effort adopted independently

### Documentation

- CLAUDE.md updated with new "Adopted Claude Code Features" tracking table, updated model selection strategy, hook conditional documentation, and claude plugin tag in release workflow

## Test Plan

- [ ] Verify hooks.json is valid JSON (validated via jq during implementation)
- [ ] Confirm skills with `paths:` still function correctly (hot-reload — no reinstall needed)
- [ ] Test that `initialPrompt` agents auto-start when invoked via Task tool
- [ ] Verify `keep-coding-instructions: true` retains CLAUDE.md preferences in /writer
- [ ] Run `/bump-version` to confirm claude plugin tag integration works
- [ ] Confirm `effort: xhigh` on /architect and /lfg produces valid API calls

Closes #43