### PR TITLE
fix(clean-branch): resolve three production bugs causing stale PR cleanup

### DIFF
--- a/plugins/psd-coding-system/skills/clean-branch/SKILL.md
+++ b/plugins/psd-coding-system/skills/clean-branch/SKILL.md
@@ -31,9 +31,18 @@ First, determine what branch you're on and find the associated merged PR and iss
 CURRENT_BRANCH=$(git branch --show-current)
 echo "Current branch: $CURRENT_BRANCH"
 
-# Find merged PR for this branch — this is ground truth
-MERGED_PR=$(gh pr list --state merged --head "$CURRENT_BRANCH" --limit 1 --json number,title --jq '.[0]')
-echo "Merged PR: $MERGED_PR"
+# Find merged PR for this branch — extract number and title as separate variables
+PR_NUMBER=$(gh pr list --state merged --head "$CURRENT_BRANCH" --limit 1 --json number --jq '.[0].number // empty')
+PR_TITLE=$(gh pr list --state merged --head "$CURRENT_BRANCH" --limit 1 --json title --jq '.[0].title // empty')
+echo "Merged PR: #$PR_NUMBER — $PR_TITLE"
+
+# Guard: stop if no merged PR found for this branch
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: No merged PR found for branch '$CURRENT_BRANCH'."
+  echo "This skill only cleans up branches that have a merged PR."
+  echo "If the PR was merged from a different branch name, switch to that branch first."
+  exit 1
+fi
 ```
 
 **If no merged PR is found for the current branch, stop immediately and report:**
@@ -44,7 +53,7 @@ Do NOT fall back to guessing, searching other branches, or using PRs from prior 
 
 ```bash
 # Get full PR details to find issue number (only if merged PR was found)
-gh pr view <PR_NUMBER> --json number,title,body
+gh pr view "$PR_NUMBER" --json number,title,body
 ```
 
 ### Phase 2: Branch Cleanup
@@ -52,19 +61,19 @@ gh pr view <PR_NUMBER> --json number,title,body
 Dynamically detect the repository's default branch — do NOT hardcode `dev` or `main`:
 
 ```bash
-# Detect the default branch dynamically
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+# Detect the default branch dynamically (with fallback matching lfg/work skills)
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
 echo "Default branch: $DEFAULT_BRANCH"
 
 # Switch to default branch and pull latest
 git checkout "$DEFAULT_BRANCH"
 git pull origin "$DEFAULT_BRANCH"
 
-# Delete local feature branch
-git branch -d <BRANCH_NAME>
+# Delete local feature branch (use $CURRENT_BRANCH captured in Phase 1)
+git branch -d "$CURRENT_BRANCH"
 
 # Delete remote feature branch
-git push origin --delete <BRANCH_NAME>
+git push origin --delete "$CURRENT_BRANCH"
 ```
 
 ### Phase 3: Close Associated Issue
@@ -76,7 +85,7 @@ Close the GitHub issue with a summary of what was completed:
 gh issue view <ISSUE_NUMBER>
 
 # Close issue with comment summarizing the work
-gh issue close <ISSUE_NUMBER> --comment "Completed in PR #<PR_NUMBER>.
+gh issue close <ISSUE_NUMBER> --comment "Completed in PR #$PR_NUMBER.
 
 <Brief 1-2 sentence summary of what was implemented/fixed>
 

--- a/plugins/psd-coding-system/skills/clean-branch/SKILL.md
+++ b/plugins/psd-coding-system/skills/clean-branch/SKILL.md
@@ -3,7 +3,7 @@ name: clean-branch
 description: Clean up merged branches, close issues, and extract compound learning insights
 model: claude-opus-4-6
 effort: high
-context: fork
+context: new
 agent: general-purpose
 allowed-tools:
   - Bash(*)
@@ -16,33 +16,49 @@ extended-thinking: true
 
 # Branch Cleanup & PR Retrospective
 
-You've just merged a PR to dev. Now complete the post-merge cleanup workflow.
+You've just merged a PR. Now complete the post-merge cleanup workflow.
 
 ## Workflow
 
 ### Phase 1: Identify Current State
 
+**CRITICAL**: The current branch from the shell is authoritative. Ignore any prior conversation context referencing other PRs or branches — only clean up the PR associated with the CURRENT branch as reported by `git branch --show-current`.
+
 First, determine what branch you're on and find the associated merged PR and issue:
 
 ```bash
-# Get current branch name
-git branch --show-current
+# Get current branch name — this is the ONLY source of truth
+CURRENT_BRANCH=$(git branch --show-current)
+echo "Current branch: $CURRENT_BRANCH"
 
-# Find merged PR for this branch
-gh pr list --state merged --head $(git branch --show-current) --limit 1
+# Find merged PR for this branch — this is ground truth
+MERGED_PR=$(gh pr list --state merged --head "$CURRENT_BRANCH" --limit 1 --json number,title --jq '.[0]')
+echo "Merged PR: $MERGED_PR"
+```
 
-# Get full PR details to find issue number
+**If no merged PR is found for the current branch, stop immediately and report:**
+
+> No merged PR found for branch `$CURRENT_BRANCH`. This skill only cleans up branches that have a merged PR. If the PR was merged from a different branch name, switch to that branch first.
+
+Do NOT fall back to guessing, searching other branches, or using PRs from prior conversation context.
+
+```bash
+# Get full PR details to find issue number (only if merged PR was found)
 gh pr view <PR_NUMBER> --json number,title,body
 ```
 
 ### Phase 2: Branch Cleanup
 
-Perform standard cleanup operations:
+Dynamically detect the repository's default branch — do NOT hardcode `dev` or `main`:
 
 ```bash
-# Switch to dev and pull latest
-git checkout dev
-git pull origin dev
+# Detect the default branch dynamically
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+echo "Default branch: $DEFAULT_BRANCH"
+
+# Switch to default branch and pull latest
+git checkout "$DEFAULT_BRANCH"
+git pull origin "$DEFAULT_BRANCH"
 
 # Delete local feature branch
 git branch -d <BRANCH_NAME>
@@ -64,7 +80,7 @@ gh issue close <ISSUE_NUMBER> --comment "Completed in PR #<PR_NUMBER>.
 
 <Brief 1-2 sentence summary of what was implemented/fixed>
 
-Changes merged to dev."
+Changes merged to $DEFAULT_BRANCH."
 ```
 
 ## Important Notes
@@ -72,6 +88,7 @@ Changes merged to dev."
 - **PR Analysis**: Compound engineering analysis happens automatically via the Stop hook
 - **No manual telemetry**: The telemetry system will detect this command and analyze the PR for learning opportunities
 - **Summary format**: Keep issue close comments concise but informative
+- **Branch authority**: Always trust `git branch --show-current` over any conversation context
 
 ## What Happens Automatically
 


### PR DESCRIPTION
## Summary

Fixes three bugs in `/clean-branch` observed in production — all three invocations after merging PRs #42, #49, #50 incorrectly reported on PR #42.

- **Bug 1**: `context: fork` caused inherited stale parent context. Changed to `context: new` for clean-slate invocations
- **Bug 2**: Phase 1 lacked authoritative shell-based PR detection. Added CRITICAL directive, structured variable capture, and explicit early-exit when no merged PR found
- **Bug 3**: Hardcoded `git checkout dev` fails in repos using `main`. Replaced with dynamic `gh repo view --json defaultBranchRef` detection

## Changes
- `plugins/psd-coding-system/skills/clean-branch/SKILL.md` — single file, all three fixes

## Test Plan
- [ ] Run `/clean-branch` on a branch with a merged PR — should detect correct PR from shell, not conversation context
- [ ] Run `/clean-branch` on a branch with no merged PR — should exit early with clear message
- [ ] Verify default branch detection works (should resolve to `main` for this repo)