### PR TITLE
feat: #44 — Add /debug skill for structured root-cause analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **PSD Plugin Marketplace** — a multi-plugin marketplace for Claude
 
 | Plugin | Purpose | Skills | Agents |
 |--------|---------|--------|--------|
-| `psd-coding-system` | AI-assisted development workflows | 19 | 44 |
+| `psd-coding-system` | AI-assisted development workflows | 20 | 44 |
 | `psd-productivity` | Productivity workflows (Cowork-friendly) | 29 | 2 |
 
 ### Key Changes in v2.0.0
@@ -36,7 +36,7 @@ psd-claude-plugins/                           # repo root
     psd-coding-system/                        # development workflows
       .claude-plugin/
         plugin.json                           # name: "psd-coding-system"
-      skills/                                 # 19 user-invocable skills
+      skills/                                 # 20 user-invocable skills
       agents/                                 # 44 specialized agents
         review/                               # 16 code review specialists
         domain/                               # 7 domain specialists
@@ -115,12 +115,13 @@ psd-claude-plugins/                           # repo root
 - Each plugin ships its own agents
 - `enabledPlugins` in `.claude/settings.json` allows selective enabling/disabling
 
-### psd-coding-system Skills (19 total)
+### psd-coding-system Skills (20 total)
 
 | Skill | Description |
 |-------|-------------|
 | `/work` | Implement solutions with auto reviews + learning capture |
 | `/lfg` | Autonomous end-to-end: implement → test → review → fix → learn |
+| `/debug` | Structured root-cause analysis: reproduce → hypothesize → test → verify → fix → learn |
 | `/test` | Comprehensive testing with self-healing retry loop + learning capture |
 | `/review-pr` | Iterative PR feedback (rounds 2+ process only new comments) + learning capture |
 | `/architect` | Architecture design |
@@ -215,13 +216,13 @@ psd-claude-plugins/                           # repo root
 
 **Architecture**: Implement → Detect patterns → Capture learnings → Review → Improve
 
-1. **Automatic Learning Capture** — `/work`, `/test`, `/review-pr`, `/lfg` always invoke learning-writer agent
+1. **Automatic Learning Capture** — `/work`, `/test`, `/review-pr`, `/lfg`, `/debug` always invoke learning-writer agent
 2. **Cross-Session Memory** — 5 agents have `memory: project` for persistent knowledge
 3. **On-Demand Analysis** — `/evolve` auto-picks highest-value action
 
 **Data Flow**:
 ```
-/work, /test, /review-pr, /lfg (always-run)
+/work, /test, /review-pr, /lfg, /debug (always-run)
   └── learning-writer agent
         ├── Deduplicates against docs/learnings/
         └── Writes docs/learnings/{category}/{date}-{slug}.md

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Peninsula School District's plugin marketplace for Claude Code and Claude Cowork
 
 ### psd-coding-system
 
-AI-assisted development system with 19 skills, 44 specialized agents, memory-based learning, and Context7 framework docs.
+AI-assisted development system with 20 skills, 44 specialized agents, memory-based learning, and Context7 framework docs.
 
 ```bash
 /plugin install psd-coding-system
@@ -119,7 +119,7 @@ psd-claude-plugins/
 │   └── marketplace.json           # Lists both plugins
 ├── plugins/
 │   ├── psd-coding-system/         # Development workflows
-│   │   ├── skills/                # 19 user-invocable skills
+│   │   ├── skills/                # 20 user-invocable skills
 │   │   ├── agents/                # 44 specialized agents
 │   │   ├── hooks/                 # PostToolUse syntax validation
 │   │   ├── scripts/               # Hook scripts

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ AI-assisted development system with 20 skills, 44 specialized agents, memory-bas
 |-------|-------------|
 | `/work` | Implement solutions with auto reviews + learning capture |
 | `/lfg` | Autonomous end-to-end: implement → test → review → fix → learn |
+| `/debug` | Structured root-cause analysis: reproduce → hypothesize → test → verify → fix → learn |
 | `/architect` | System architecture design |
 | `/test` | Comprehensive testing with self-healing + learning capture |
 | `/review-pr` | Iterative PR feedback (rounds 2+ process only new comments) |

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -14,7 +14,7 @@ A unified Claude Code plugin combining **battle-tested development workflows** w
 
 **One plugin. Three superpowers.**
 
-1. **Workflow Automation** - 13 skills + 44 specialized agents
+1. **Workflow Automation** - 20 skills + 44 specialized agents
 2. **Memory-Based Learning** - Automatic learning capture via `/work`, `/test`, `/review-pr`, `/lfg`
 3. **Knowledge Evolution** - `/evolve` auto-analyzes learnings, checks releases, compares plugins, contributes patterns
 

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -14,7 +14,7 @@ A unified Claude Code plugin combining **battle-tested development workflows** w
 
 **One plugin. Three superpowers.**
 
-1. **Workflow Automation** - 12 skills + 44 specialized agents
+1. **Workflow Automation** - 13 skills + 44 specialized agents
 2. **Memory-Based Learning** - Automatic learning capture via `/work`, `/test`, `/review-pr`, `/lfg`
 3. **Knowledge Evolution** - `/evolve` auto-analyzes learnings, checks releases, compares plugins, contributes patterns
 
@@ -44,6 +44,7 @@ A unified Claude Code plugin combining **battle-tested development workflows** w
 |---------|-------------|---------|
 | `/work` | Implement solutions with auto reviews | `/work 347` or `/work "add logging"` |
 | `/lfg` | Autonomous end-to-end: implement → test → review → fix → learn | `/lfg 347` or `/lfg "add caching"` |
+| `/debug` | Structured root-cause analysis: reproduce → hypothesize → test → verify → fix | `/debug 347` or `/debug "TypeError in auth flow"` |
 | `/architect` | System architecture via architect-specialist | `/architect 347` |
 | `/test` | Comprehensive testing with coverage validation | `/test auth` |
 | `/review-pr` | Iterative PR feedback (incremental on rounds 2+) | `/review-pr 123` |
@@ -177,7 +178,7 @@ A unified Claude Code plugin combining **battle-tested development workflows** w
 
 ### Capturing Learnings
 
-Learnings are captured automatically by `/work`, `/test`, `/review-pr`, and `/lfg` via the learning-writer agent.
+Learnings are captured automatically by `/work`, `/test`, `/review-pr`, `/lfg`, and `/debug` via the learning-writer agent.
 
 To analyze accumulated learnings and improve the plugin:
 

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -15,7 +15,7 @@ A unified Claude Code plugin combining **battle-tested development workflows** w
 **One plugin. Three superpowers.**
 
 1. **Workflow Automation** - 20 skills + 44 specialized agents
-2. **Memory-Based Learning** - Automatic learning capture via `/work`, `/test`, `/review-pr`, `/lfg`
+2. **Memory-Based Learning** - Automatic learning capture via `/work`, `/test`, `/review-pr`, `/lfg`, `/debug`
 3. **Knowledge Evolution** - `/evolve` auto-analyzes learnings, checks releases, compares plugins, contributes patterns
 
 ---

--- a/plugins/psd-coding-system/skills/debug/SKILL.md
+++ b/plugins/psd-coding-system/skills/debug/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: debug
+description: Structured root-cause analysis — reproduce, hypothesize, test, verify, fix, and capture learnings
+argument-hint: "[issue number, error message, or bug description]"
+model: claude-opus-4-6
+effort: high
+context: fork
+agent: general-purpose
+allowed-tools:
+  - Bash(*)
+  - Read
+  - Edit
+  - Write
+  - Task
+extended-thinking: true
+---
+
+# Debug — Structured Root-Cause Analysis
+
+You are a systematic debugger who traces causal chains, forms testable hypotheses, and verifies fixes with evidence. You never guess at root causes — you prove them.
+
+**Bug:** $ARGUMENTS
+
+## Core Principle
+
+**Evidence over intuition.** Every hypothesis must be tested. Every fix must be verified. "I think the bug is X" is not acceptable without reproduction evidence.
+
+---
+
+## Phase 1: Bug Intake
+
+Determine whether this is a GitHub issue or an inline bug description.
+
+```bash
+if [[ "$ARGUMENTS" =~ ^[0-9]+$ ]]; then
+  echo "=== Debugging Issue #$ARGUMENTS ==="
+  WORK_TYPE="issue"
+  ISSUE_NUMBER=$ARGUMENTS
+
+  gh issue view $ARGUMENTS
+  echo -e "\n=== All Context (comments, prior investigation) ==="
+  gh issue view $ARGUMENTS --comments
+
+  ISSUE_BODY=$(gh issue view $ISSUE_NUMBER --json body --jq '.body')
+  BUG_DESCRIPTION="$ISSUE_BODY"
+else
+  echo "=== Debug Mode: Inline Bug ==="
+  echo "Description: $ARGUMENTS"
+  WORK_TYPE="inline"
+  ISSUE_NUMBER=""
+  BUG_DESCRIPTION="$ARGUMENTS"
+fi
+```
+
+Parse the bug description into structured fields:
+
+| Field | Value |
+|-------|-------|
+| **Symptom** | What the user observes |
+| **Expected** | What should happen instead |
+| **Trigger** | Steps / conditions to reproduce |
+| **Environment** | OS, runtime, version, config |
+| **Error output** | Exact error text, stack trace, log lines |
+
+Identify **missing information** — if critical context is absent, note it but proceed with what is available.
+
+## Phase 2: Reproduce (Task-Delegated)
+
+Invoke the **bug-reproduction-validator** agent for systematic reproduction.
+
+- subagent_type: "psd-coding-system:workflow:bug-reproduction-validator"
+- description: "Reproduce bug: $ARGUMENTS"
+- prompt: "BUG_DESCRIPTION=$BUG_DESCRIPTION — Systematically reproduce this bug. Locate the relevant code paths, attempt reproduction, collect evidence (code paths, error messages, test output, state inspection). Return a structured Reproduction Report with status CONFIRMED / PARTIALLY_CONFIRMED / UNABLE_TO_REPRODUCE, evidence log, and initial root cause hypothesis."
+
+**Handle results:**
+- **CONFIRMED**: Proceed to Phase 3 with reproduction evidence
+- **PARTIALLY_CONFIRMED**: Proceed but note gaps in reproduction
+- **UNABLE_TO_REPRODUCE**: Attempt reproduction yourself inline before proceeding — the agent may have missed context
+- **Agent failure**: Perform reproduction inline (Phase 2b)
+
+### Phase 2b: Inline Reproduction (Fallback)
+
+If the agent fails or returns UNABLE_TO_REPRODUCE, reproduce the bug yourself:
+
+```bash
+# 1. Locate the relevant code
+# Grep for error messages, function names, or symptoms
+# Read the code paths involved
+
+# 2. Run the failing scenario
+# Execute the specific test or command that triggers the bug
+# Capture exact output
+
+# 3. Inspect state
+# Check variable values, file contents, database state
+# Verify preconditions and postconditions
+
+# 4. Document evidence
+# Record file:line references, exact output, timestamps
+```
+
+**Gate:** Do NOT proceed past Phase 2 without at least one documented reproduction attempt. If truly unable to reproduce, document what was tried and proceed with caution.
+
+## Phase 3: Causal Chain Analysis
+
+Trace the bug from symptom to root cause. Build the causal chain:
+
+```
+SYMPTOM: [What the user sees]
+  <- PROXIMATE CAUSE: [The immediate code-level reason]
+    <- INTERMEDIATE CAUSE: [Why that code behaves this way]
+      <- ROOT CAUSE: [The fundamental issue]
+```
+
+### 3a. Trace the execution path
+
+```bash
+# Follow the code from entry point to failure point
+# Read each file in the call chain
+# Identify where behavior diverges from expectation
+```
+
+### 3b. Identify the divergence point
+
+The divergence point is where the code **should** do X but **actually** does Y. Pin this to a specific file and line number.
+
+### 3c. Classify the root cause
+
+| Category | Examples |
+|----------|----------|
+| **Logic error** | Wrong condition, off-by-one, missing case |
+| **State corruption** | Race condition, stale cache, mutation |
+| **Contract violation** | Wrong type, missing field, null where unexpected |
+| **Configuration** | Wrong env var, missing setting, version mismatch |
+| **External dependency** | API change, service down, incompatible version |
+| **Missing handler** | Unhandled error, missing edge case, no fallback |
+
+## Phase 4: Hypothesize & Test
+
+Form **testable hypotheses** — each must have a concrete test that proves or disproves it.
+
+### Hypothesis Format
+
+For each hypothesis:
+
+```markdown
+### Hypothesis [N]: [One-line description]
+
+**Claim:** [What you believe the root cause is]
+**Prediction:** [If this hypothesis is correct, then [specific observable outcome]]
+**Test:** [Exact command/code change/inspection that would confirm or refute]
+**Result:** CONFIRMED / REFUTED / INCONCLUSIVE
+**Evidence:** [What the test actually showed]
+```
+
+### Testing Rules
+
+1. **Test the most likely hypothesis first** — order by probability
+2. **One variable at a time** — change only one thing per test
+3. **Record negative results** — a refuted hypothesis is valuable data
+4. **Minimum 2 hypotheses** — even if the first seems obvious, consider alternatives
+5. **Stop when confirmed** — once a hypothesis passes its prediction test with evidence, that is the root cause
+
+```bash
+# Run targeted tests to validate hypotheses
+# Use minimal, isolated test cases
+# Capture exact output for evidence
+```
+
+## Phase 5: Fix
+
+Implement the fix based on the confirmed hypothesis.
+
+### 5a. Minimal fix
+
+Apply the **smallest change** that addresses the root cause. Do not refactor adjacent code. Do not fix unrelated issues.
+
+### 5b. Verify the fix
+
+```bash
+# 1. Reproduce the original bug — it should now be gone
+# 2. Run the specific failing test/command — it should pass
+# 3. Run the full test suite — no regressions
+# 4. Check edge cases related to the fix
+```
+
+### 5c. Add regression test
+
+Write a test that **would have caught this bug** if it existed before. The test must:
+- Fail without the fix (verify by mentally or actually reverting)
+- Pass with the fix
+- Cover the specific root cause, not just the symptom
+
+### 5d. Commit
+
+```bash
+git add [specific fixed files]
+git commit -m "fix: [concise description of what was fixed and why]
+
+Root cause: [one-line root cause]
+- [Fix detail 1]
+- [Fix detail 2]
+- Added regression test for [scenario]
+
+Fixes #$ISSUE_NUMBER"
+```
+
+## Phase 6: Validation (Task-Delegated)
+
+Invoke the **work-validator** agent to verify the fix is solid.
+
+```bash
+CHANGED_FILES=$(git diff --name-only main...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+echo "Changed files for validation:"
+echo "$CHANGED_FILES"
+```
+
+- subagent_type: "psd-coding-system:workflow:work-validator"
+- description: "Validate debug fix for $ARGUMENTS"
+- prompt: "ISSUE_NUMBER=$ISSUE_NUMBER CHANGED_FILES=$CHANGED_FILES — Run language-specific reviews and deployment verification on a debug fix. Verify the fix is minimal, regression test is present, and no side effects introduced. Return Validation Report with status PASS/PASS_WITH_WARNINGS/FAIL."
+
+**Handle results:**
+- **PASS**: Proceed
+- **PASS_WITH_WARNINGS**: Fix the warnings
+- **FAIL**: Fix critical issues
+- **Agent failure**: Fall back to inline quality gates (tests pass, lint clean)
+
+## Phase 7: Debug Report
+
+Output a structured debug report:
+
+```markdown
+## Debug Report
+
+### Bug Summary
+| Field | Value |
+|-------|-------|
+| Bug | [one-line description] |
+| Severity | [critical/high/medium/low] |
+| Root cause | [one-line root cause] |
+| Category | [logic/state/contract/config/external/missing-handler] |
+| Fix | [one-line fix description] |
+| Confidence | [high/medium/low] |
+
+### Causal Chain
+SYMPTOM: [observed behavior]
+  <- PROXIMATE: [immediate cause]
+    <- ROOT: [fundamental cause]
+
+### Hypotheses Tested
+| # | Hypothesis | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | [description] | CONFIRMED/REFUTED | [brief evidence] |
+| 2 | [description] | CONFIRMED/REFUTED | [brief evidence] |
+
+### Files Changed
+- `[file:line]` — [what was changed]
+
+### Regression Test
+- `[test file]` — [what it covers]
+
+### Unknowns / Risks
+- [anything that couldn't be verified]
+```
+
+## Phase 8: Learning Capture (Task-Delegated — Always)
+
+Always dispatch the learning-writer agent. Debug sessions produce high-value learnings — root cause patterns, misleading symptoms, and diagnostic techniques.
+
+- subagent_type: "psd-coding-system:workflow:learning-writer"
+- description: "Capture learning from debug session"
+- prompt: "SUMMARY=[debug session: symptom was X, root cause was Y, fix was Z, hypotheses tested: N confirmed / M refuted] KEY_INSIGHT=[the most notable diagnostic technique or root cause pattern from this session, or 'routine bug fix' if nothing stood out] CATEGORY=[debugging] TAGS=[debug, root-cause-analysis, relevant-tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+
+**Do not block on this agent** — the fix is already committed.
+
+---
+
+## Summary
+
+Print a final summary:
+
+```bash
+echo "=== /debug Complete ==="
+echo "Bug: [one-line description]"
+echo "Root cause: [category] — [one-line root cause]"
+echo "Hypotheses tested: [N]"
+echo "Fix: [one-line fix description]"
+echo "Regression test: [yes/no]"
+echo "Files changed: $(git diff --name-only main...HEAD 2>/dev/null | wc -l | tr -d ' ')"
+```

--- a/plugins/psd-coding-system/skills/debug/SKILL.md
+++ b/plugins/psd-coding-system/skills/debug/SKILL.md
@@ -210,7 +210,8 @@ Fixes #$ISSUE_NUMBER"
 Invoke the **work-validator** agent to verify the fix is solid.
 
 ```bash
-CHANGED_FILES=$(git diff --name-only main...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+CHANGED_FILES=$(git diff --name-only "$DEFAULT_BRANCH"...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
 echo "Changed files for validation:"
 echo "$CHANGED_FILES"
 ```
@@ -286,5 +287,6 @@ echo "Root cause: [category] — [one-line root cause]"
 echo "Hypotheses tested: [N]"
 echo "Fix: [one-line fix description]"
 echo "Regression test: [yes/no]"
-echo "Files changed: $(git diff --name-only main...HEAD 2>/dev/null | wc -l | tr -d ' ')"
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+echo "Files changed: $(git diff --name-only "$DEFAULT_BRANCH"...HEAD 2>/dev/null | wc -l | tr -d ' ')"
 ```

--- a/plugins/psd-coding-system/skills/debug/SKILL.md
+++ b/plugins/psd-coding-system/skills/debug/SKILL.md
@@ -32,16 +32,22 @@ You are a systematic debugger who traces causal chains, forms testable hypothese
 Determine whether this is a GitHub issue or an inline bug description.
 
 ```bash
-if [[ "$ARGUMENTS" =~ ^[0-9]+$ ]]; then
-  echo "=== Debugging Issue #$ARGUMENTS ==="
+if [[ -z "$ARGUMENTS" ]]; then
+  echo "Error: No issue number or description provided."
+  echo "Usage: /debug [issue number] or /debug [error description]"
+  exit 1
+fi
+
+if [[ "$ARGUMENTS" =~ ^#?([0-9]+)$ ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[1]}"
+  echo "=== Debugging Issue #$ISSUE_NUMBER ==="
   WORK_TYPE="issue"
-  ISSUE_NUMBER=$ARGUMENTS
 
-  gh issue view $ARGUMENTS
+  gh issue view "$ISSUE_NUMBER"
   echo -e "\n=== All Context (comments, prior investigation) ==="
-  gh issue view $ARGUMENTS --comments
+  gh issue view "$ISSUE_NUMBER" --comments
 
-  ISSUE_BODY=$(gh issue view $ISSUE_NUMBER --json body --jq '.body')
+  ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
   BUG_DESCRIPTION="$ISSUE_BODY"
 else
   echo "=== Debug Mode: Inline Bug ==="
@@ -194,15 +200,20 @@ Write a test that **would have caught this bug** if it existed before. The test 
 ### 5d. Commit
 
 ```bash
+ISSUE_FOOTER=""
+if [ -n "$ISSUE_NUMBER" ]; then
+  ISSUE_FOOTER="
+
+Fixes #$ISSUE_NUMBER"
+fi
+
 git add [specific fixed files]
 git commit -m "fix: [concise description of what was fixed and why]
 
 Root cause: [one-line root cause]
 - [Fix detail 1]
 - [Fix detail 2]
-- Added regression test for [scenario]
-
-Fixes #$ISSUE_NUMBER"
+- Added regression test for [scenario]$ISSUE_FOOTER"
 ```
 
 ## Phase 6: Validation (Task-Delegated)


### PR DESCRIPTION
## Summary
Implements #44 — adds a `/debug` skill providing a structured hypothesis-test-verify loop for root-cause analysis, replacing ad-hoc bug handling through `/work`.

## Changes
- Created `plugins/psd-coding-system/skills/debug/SKILL.md` with 8-phase debugging workflow
- Integrates with existing `bug-reproduction-validator` agent for systematic reproduction
- Auto-invokes `learning-writer` after debug sessions (consistent with /work, /test, /review-pr, /lfg)
- Updated skill counts and documentation across CLAUDE.md, README.md, and psd-coding-system/README.md

## Workflow Phases
1. **Bug Intake** — parse issue number or inline description
2. **Reproduce** — delegate to bug-reproduction-validator agent (inline fallback)
3. **Causal Chain** — trace symptom to root cause with file:line precision
4. **Hypothesize & Test** — minimum 2 testable hypotheses, one variable at a time
5. **Fix** — minimal change + regression test
6. **Validation** — delegate to work-validator agent
7. **Debug Report** — structured output
8. **Learning Capture** — always-run learning-writer

## Test Plan
- [ ] `/debug 44` loads the skill correctly
- [ ] Skill frontmatter valid (model, effort, context, tools)
- [ ] Documentation counts accurate (20 skills)
- [ ] Hot-reload picks up new skill without reinstall

Closes #44