### PR TITLE
feat: #56 — adopt Claude Code v2.1.83-v2.1.122 features in plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,11 +246,22 @@ The `psd-coding-system` plugin configures a Context7 MCP server providing live f
 
 ### Hooks
 
-**PostToolUse Hook** (`scripts/post-edit-validate.sh`):
+**PostToolUse Hook — Syntax Validation** (`scripts/post-edit-validate.sh`):
 - Runs after Edit or Write tool calls (matcher: `Edit|Write`)
 - `if` conditional (v2.1.85): only fires for `.ts/.tsx/.py/.json` files — skips `.md`, `.sh`, `.yaml`, etc.
 - Validates file syntax: `.ts/.tsx` (tsc), `.py` (py_compile), `.json` (jq)
 - Non-blocking, 10s timeout
+
+**PostToolUse Hook — Secret Redaction** (`scripts/redact-secrets.sh`):
+- Runs after Bash tool calls (matcher: `Bash`)
+- Uses `outputReplace: true` (v2.1.121) to replace output before Claude sees it
+- Redacts: API keys (sk-*, ghp_*, AKIA*), Bearer tokens, Google/Slack keys, password/secret assignments
+- Non-blocking, 5s timeout
+
+**PreCompact Hook** (`scripts/pre-compact-context.sh`):
+- Runs before context compaction (v2.1.105)
+- Outputs current branch, uncommitted changes, recent commits, and active issue number
+- Output is injected into compacted conversation to preserve task context
 
 **WorktreeCreate/Remove Hooks** (v2.1.50+):
 - Auto-symlinks `.env` into worktrees; logs cleanup on removal
@@ -387,7 +398,8 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 - Learnings auto-deleted after 90 days by `/evolve` TTL cleanup
 - Agent memory stored locally in `.claude/agent-memory/`
 - No telemetry collection
-- Only PostToolUse hook runs automatically (syntax validation)
+- PostToolUse hooks run automatically (syntax validation + secret redaction)
+- PreCompact hook preserves branch/task context during compaction
 
 ### Model Selection Strategy
 - **sonnet-4-6**: Default for agents and lightweight coding tasks
@@ -415,6 +427,11 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 | `initialPrompt:` agent auto-submit | v2.1.83 | 4 agents | learning-writer, work-researcher, meta-reviewer, work-validator |
 | `paths:` file access scoping | v2.1.84 | 5 skills | enrollment, pdf-builder, documenso, docusign, n8n |
 | `if` hook conditionals | v2.1.85 | PostToolUse hook | Only fires for .ts/.tsx/.py/.json files |
-| `keep-coding-instructions:` | v2.1.94 | 7 skills | writer, sop-creator, presentation-master, seven-advisors, chief-of-staff, assistant-architect, strategic-planning-manager |
+| `keep-coding-instructions:` | v2.1.94 | 10 skills/agents | 7 skills + work-researcher, learning-writer, test-specialist |
+| `PreCompact` hook | v2.1.105 | hooks.json | Preserves branch, commits, active issue before compaction |
 | `effort: xhigh` | v2.1.111 | 5 skills/agents | architect, product-manager, lfg, evolve, meta-reviewer |
+| Agent `mcpServers` frontmatter | v2.1.117 | 3 agents | framework-docs-researcher, best-practices-researcher, repo-research-analyst |
 | `claude plugin tag` | v2.1.118 | bump-version skill | Replaces manual git tag in release workflow |
+| `$schema` in plugin.json | v2.1.120 | Both plugins | Enables `claude plugin validate` |
+| `alwaysLoad` MCP config | v2.1.121 | psd-coding-system | Context7 resolve-library-id + query-docs eagerly loaded |
+| PostToolUse `outputReplace` | v2.1.121 | hooks.json | Auto-redacts secrets from Bash output |

--- a/plugins/psd-coding-system/.claude-plugin/plugin.json
+++ b/plugins/psd-coding-system/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-coding-system",
   "version": "2.2.0",
   "description": "AI-assisted development system for Peninsula School District - workflow automation, specialized agents, memory-based learning, and Context7 framework docs",
@@ -22,7 +23,8 @@
   "mcpServers": {
     "context7": {
       "type": "http",
-      "url": "https://mcp.context7.com/mcp"
+      "url": "https://mcp.context7.com/mcp",
+      "alwaysLoad": ["resolve-library-id", "query-docs"]
     }
   }
 }

--- a/plugins/psd-coding-system/agents/quality/test-specialist.md
+++ b/plugins/psd-coding-system/agents/quality/test-specialist.md
@@ -5,6 +5,7 @@ tools: Bash, Read, Edit, Write, WebSearch
 model: claude-sonnet-4-6
 memory: project
 extended-thinking: true
+keep-coding-instructions: true
 color: green
 ---
 

--- a/plugins/psd-coding-system/agents/research/best-practices-researcher.md
+++ b/plugins/psd-coding-system/agents/research/best-practices-researcher.md
@@ -4,6 +4,8 @@ description: Two-phase knowledge lookup (local → online) with mandatory deprec
 tools: Read, Grep, Glob, WebSearch, WebFetch
 model: claude-sonnet-4-6
 extended-thinking: true
+mcpServers:
+  - context7
 color: blue
 ---
 

--- a/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
+++ b/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
@@ -4,6 +4,8 @@ description: Validates frameworks and APIs are not deprecated, sunset, or EOL be
 tools: Read, Grep, Glob, WebSearch, WebFetch
 model: claude-sonnet-4-6
 extended-thinking: true
+mcpServers:
+  - context7
 color: blue
 ---
 

--- a/plugins/psd-coding-system/agents/research/repo-research-analyst.md
+++ b/plugins/psd-coding-system/agents/research/repo-research-analyst.md
@@ -4,6 +4,8 @@ description: Codebase onboarding and deep research agent for architecture mappin
 tools: Read, Grep, Glob, WebSearch
 model: claude-sonnet-4-6
 extended-thinking: true
+mcpServers:
+  - context7
 color: blue
 ---
 

--- a/plugins/psd-coding-system/agents/workflow/learning-writer.md
+++ b/plugins/psd-coding-system/agents/workflow/learning-writer.md
@@ -5,6 +5,7 @@ tools: Read, Write, Grep, Glob
 model: claude-sonnet-4-6
 memory: project
 background: true
+keep-coding-instructions: true
 initialPrompt: "Process the session summary provided in $ARGUMENTS. Deduplicate against existing learnings in docs/learnings/, then write a new learning document if the insight is novel."
 color: yellow
 ---

--- a/plugins/psd-coding-system/agents/workflow/work-researcher.md
+++ b/plugins/psd-coding-system/agents/workflow/work-researcher.md
@@ -5,6 +5,7 @@ tools: Bash, Read, Grep, Glob, Task
 model: claude-sonnet-4-6
 memory: project
 extended-thinking: true
+keep-coding-instructions: true
 initialPrompt: "Begin pre-implementation research using the context in $ARGUMENTS. Detect environment, route research, dispatch sub-agents in parallel, and return a structured Research Brief."
 color: blue
 ---

--- a/plugins/psd-coding-system/hooks/hooks.json
+++ b/plugins/psd-coding-system/hooks/hooks.json
@@ -13,6 +13,17 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact-context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "WorktreeCreate": [
       {
         "hooks": [

--- a/plugins/psd-coding-system/hooks/hooks.json
+++ b/plugins/psd-coding-system/hooks/hooks.json
@@ -11,6 +11,17 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/redact-secrets.sh",
+            "timeout": 5,
+            "outputReplace": true
+          }
+        ]
       }
     ],
     "PreCompact": [

--- a/plugins/psd-coding-system/scripts/pre-compact-context.sh
+++ b/plugins/psd-coding-system/scripts/pre-compact-context.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 
 echo "=== Pre-Compaction Context Snapshot ==="
 
+# Guard: exit cleanly if not inside a git worktree (e.g., non-git directory).
+# Without this, set -e would abort on any failing git command.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not inside a git repository — skipping context snapshot."
+  echo "=== End Context Snapshot ==="
+  exit 0
+fi
+
 # 1. Current branch and uncommitted work
 BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 echo "Branch: $BRANCH"

--- a/plugins/psd-coding-system/scripts/pre-compact-context.sh
+++ b/plugins/psd-coding-system/scripts/pre-compact-context.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# pre-compact-context.sh — PreCompact hook
+# Outputs critical context that should be preserved during context compaction.
+# The output of this script is injected into the compacted conversation.
+
+set -euo pipefail
+
+echo "=== Pre-Compaction Context Snapshot ==="
+
+# 1. Current branch and uncommitted work
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "Branch: $BRANCH"
+
+UNCOMMITTED=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+if [ "$UNCOMMITTED" -gt 0 ]; then
+  echo "Uncommitted changes: $UNCOMMITTED files"
+  git status --short 2>/dev/null | head -15
+fi
+
+# 2. Recent commits on this branch (what we've done so far)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+COMMIT_COUNT=$(git rev-list --count "$DEFAULT_BRANCH"..HEAD 2>/dev/null || echo "0")
+if [ "$COMMIT_COUNT" -gt 0 ]; then
+  echo ""
+  echo "Commits on this branch ($COMMIT_COUNT):"
+  git log --oneline "$DEFAULT_BRANCH"..HEAD 2>/dev/null | head -10
+fi
+
+# 3. Active issue (if branch matches feature/NNN pattern)
+if [[ "$BRANCH" =~ ^feature/([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+  echo ""
+  echo "Active issue: #$ISSUE_NUM"
+fi
+
+echo "=== End Context Snapshot ==="
+
+exit 0

--- a/plugins/psd-coding-system/scripts/redact-secrets.sh
+++ b/plugins/psd-coding-system/scripts/redact-secrets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# redact-secrets.sh — PostToolUse output replacement hook for Bash
+# Scans tool output for common secret patterns and replaces them with [REDACTED].
+# Reads tool output from stdin, writes redacted output to stdout.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract the tool output
+OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty' 2>/dev/null)
+
+if [ -z "$OUTPUT" ]; then
+  exit 0
+fi
+
+# Redact common secret patterns:
+# - API keys (sk-*, xoxb-*, ghp_*, ghu_*, etc.)
+# - Bearer tokens
+# - AWS keys
+# - Base64-encoded long strings that look like secrets
+# - Password/secret assignments in env output
+REDACTED=$(echo "$OUTPUT" | sed -E \
+  -e 's/(sk-[a-zA-Z0-9]{20,})/[REDACTED]/g' \
+  -e 's/(xoxb-[a-zA-Z0-9-]{20,})/[REDACTED]/g' \
+  -e 's/(xoxp-[a-zA-Z0-9-]{20,})/[REDACTED]/g' \
+  -e 's/(ghp_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
+  -e 's/(ghu_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
+  -e 's/(ghs_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
+  -e 's/(AKIA[A-Z0-9]{16})/[REDACTED]/g' \
+  -e 's/(Bearer [a-zA-Z0-9._-]{20,})/Bearer [REDACTED]/g' \
+  -e 's/(AIza[a-zA-Z0-9_-]{35})/[REDACTED]/g' \
+  -e 's/((password|secret|token|api_key|apikey|api-key|private_key)=)[^ \t"'"'"']*/\1[REDACTED]/gi' \
+)
+
+# Only output replacement if something was actually redacted
+if [ "$OUTPUT" != "$REDACTED" ]; then
+  echo "$REDACTED"
+fi
+
+exit 0

--- a/plugins/psd-coding-system/scripts/redact-secrets.sh
+++ b/plugins/psd-coding-system/scripts/redact-secrets.sh
@@ -18,24 +18,25 @@ fi
 # - API keys (sk-*, xoxb-*, ghp_*, ghu_*, etc.)
 # - Bearer tokens
 # - AWS keys
-# - Base64-encoded long strings that look like secrets
+# - Google API keys
 # - Password/secret assignments in env output
-REDACTED=$(echo "$OUTPUT" | sed -E \
-  -e 's/(sk-[a-zA-Z0-9]{20,})/[REDACTED]/g' \
-  -e 's/(xoxb-[a-zA-Z0-9-]{20,})/[REDACTED]/g' \
-  -e 's/(xoxp-[a-zA-Z0-9-]{20,})/[REDACTED]/g' \
-  -e 's/(ghp_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
-  -e 's/(ghu_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
-  -e 's/(ghs_[a-zA-Z0-9]{36,})/[REDACTED]/g' \
-  -e 's/(AKIA[A-Z0-9]{16})/[REDACTED]/g' \
-  -e 's/(Bearer [a-zA-Z0-9._-]{20,})/Bearer [REDACTED]/g' \
-  -e 's/(AIza[a-zA-Z0-9_-]{35})/[REDACTED]/g' \
-  -e 's/((password|secret|token|api_key|apikey|api-key|private_key)=)[^ \t"'"'"']*/\1[REDACTED]/gi' \
-)
+# Uses perl instead of sed for portable case-insensitive matching (BSD sed
+# does not support the /i flag with -E, which breaks on macOS).
+REDACTED=$(echo "$OUTPUT" | perl -pe '
+  s/(sk-[a-zA-Z0-9]{20,})/[REDACTED]/g;
+  s/(xoxb-[a-zA-Z0-9-]{20,})/[REDACTED]/g;
+  s/(xoxp-[a-zA-Z0-9-]{20,})/[REDACTED]/g;
+  s/(ghp_[a-zA-Z0-9]{36,})/[REDACTED]/g;
+  s/(ghu_[a-zA-Z0-9]{36,})/[REDACTED]/g;
+  s/(ghs_[a-zA-Z0-9]{36,})/[REDACTED]/g;
+  s/(AKIA[A-Z0-9]{16})/[REDACTED]/g;
+  s/(Bearer [a-zA-Z0-9._-]{20,})/Bearer [REDACTED]/g;
+  s/(AIza[a-zA-Z0-9_-]{35})/[REDACTED]/g;
+  s/((password|secret|token|api_key|apikey|api-key|private_key)=)[^ \t"'"'"']*/$1\[REDACTED]/gi;
+')
 
-# Only output replacement if something was actually redacted
-if [ "$OUTPUT" != "$REDACTED" ]; then
-  echo "$REDACTED"
-fi
+# Always output content — outputReplace: true means our stdout replaces
+# the tool output entirely. Outputting nothing would blank valid output.
+echo "$REDACTED"
 
 exit 0

--- a/plugins/psd-productivity/.claude-plugin/plugin.json
+++ b/plugins/psd-productivity/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-productivity",
   "version": "2.11.0",
   "description": "32 productivity workflows + 1 agent for Peninsula School District — DocuSign migration/export, PDF Builder, P223 enrollment automation, n8n workflow management, Documenso document signing, Google Workspace CLI, document generation, research, TTS, and district operations",


### PR DESCRIPTION
## Summary
Implements #56 — adopts 8 new Claude Code capabilities (P0/P1/P2) that were available but not yet used in the plugin.

## Changes

### P0 — High Impact, Low Effort
- **`alwaysLoad` MCP config** (v2.1.121): Context7 tools (`resolve-library-id`, `query-docs`) eagerly loaded, eliminating deferred-search latency
- **`$schema` in plugin.json** (v2.1.120): Added to both psd-coding-system and psd-productivity, enables `claude plugin validate`
- **`keep-coding-instructions`** (v2.1.94): Added to work-researcher, learning-writer, test-specialist agents (3 new, joining 7 existing skills)

### P1 — High Impact, Medium Effort
- **`PreCompact` hook** (v2.1.105): New `pre-compact-context.sh` preserves branch, uncommitted changes, recent commits, and active issue before context compaction
- **Agent `mcpServers` frontmatter** (v2.1.117): framework-docs-researcher, best-practices-researcher, repo-research-analyst now declare Context7 dependency directly

### P2 — Medium Impact
- **PostToolUse `outputReplace`** (v2.1.121): New `redact-secrets.sh` auto-redacts API keys, Bearer tokens, AWS keys, and password assignments from Bash output before Claude sees them

### Documentation
- Updated CLAUDE.md hooks section, privacy notes, and Adopted Claude Code Features table (6 new entries)

## Not Implemented (deferred to future work)
- `monitors` manifest key (v2.1.105) — needs design for auto-learning-capture use case
- `${CLAUDE_EFFORT}` in skills (v2.1.120) — needs per-skill evaluation of where effort scaling adds value
- Custom PSD themes (v2.1.118) — cosmetic, low priority
- `CwdChanged`/`FileChanged` hooks — needs design for auto-loading learnings use case
- MCP tool hooks (`type: "mcp_tool"`) — no current use case identified

## Completion Criteria
- [x] All JSON files pass `jq` validation
- [x] All shell scripts pass `bash -n` syntax check
- [x] Agent YAML frontmatter has correct new fields
- [x] CLAUDE.md Adopted Features table updated
- [x] E2E tests: N/A — plugin config only (markdown + JSON, no application code)
- [x] Zero lint warnings on every touched file
- [x] Type check: N/A — no TypeScript files changed

## Touched Files
- CLAUDE.md
- plugins/psd-coding-system/.claude-plugin/plugin.json
- plugins/psd-coding-system/agents/quality/test-specialist.md
- plugins/psd-coding-system/agents/research/best-practices-researcher.md
- plugins/psd-coding-system/agents/research/framework-docs-researcher.md
- plugins/psd-coding-system/agents/research/repo-research-analyst.md
- plugins/psd-coding-system/agents/workflow/learning-writer.md
- plugins/psd-coding-system/agents/workflow/work-researcher.md
- plugins/psd-coding-system/hooks/hooks.json
- plugins/psd-coding-system/scripts/pre-compact-context.sh (new)
- plugins/psd-coding-system/scripts/redact-secrets.sh (new)
- plugins/psd-productivity/.claude-plugin/plugin.json

Closes #56