### PR TITLE
fix: #57 — Repair learning-writer agent (4 root causes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "PSD Plugin Marketplace for Claude Code and Claude Cowork — coding workflows, productivity agents, and district automation",
-    "version": "2.12.0",
+    "version": "2.13.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "name": "psd-coding-system",
       "source": "./plugins/psd-coding-system",
       "description": "AI-assisted development system with workflow automation, specialized agents, memory-based learning, and Context7 framework docs",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "category": "productivity",
       "keywords": [
         "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] - 2026-04-28
+
+### Added
+- **Adopt Claude Code v2.1.83-v2.1.122 features** (psd-coding-system 2.3.0, PR #58, closes #56):
+  - **`alwaysLoad` MCP config** (v2.1.121) — Context7 tools (`resolve-library-id`, `query-docs`) eagerly loaded, eliminating deferred-search latency
+  - **`$schema` in plugin.json** (v2.1.120) — added to both psd-coding-system and psd-productivity, enables `claude plugin validate`
+  - **`keep-coding-instructions: true`** (v2.1.94) — added to work-researcher, learning-writer, and test-specialist agents
+  - **`PreCompact` hook** (v2.1.105) — new `pre-compact-context.sh` preserves branch, uncommitted changes, recent commits, and active issue number before context compaction
+  - **Agent `mcpServers` frontmatter** (v2.1.117) — framework-docs-researcher, best-practices-researcher, and repo-research-analyst now declare Context7 dependency directly
+  - **PostToolUse `outputReplace`** (v2.1.121) — new `redact-secrets.sh` auto-redacts API keys, Bearer tokens, AWS keys, and password assignments from Bash output before Claude sees them (perl-based for macOS BSD portability)
+
+### Fixed
+- **learning-writer agent producing zero output** (psd-coding-system 2.3.0, PR #59, closes #57):
+  - Added `Bash` tool so the agent can run `mkdir -p` for category directories — previously `Write` failed silently when the directory did not exist
+  - Removed stale `TRIGGER_REASON` input field that no skill ever populated
+  - Removed "Skip if routine" escape hatch from all six consuming skills (`/work`, `/test`, `/review-pr`, `/lfg`, `/debug`, `/optimize`) — template placeholders were being passed literally and read as "routine," suppressing every learning capture
+  - Added `[FILL:]` prefixes to skill prompts to force real data substitution rather than placeholder text
+  - Strengthened agent behavior to "Write the learning document" unconditionally
+  - Quoted the `mkdir -p` path against special characters in category names
+  - Replaced `etc.` shorthand in `/review-pr` CATEGORY list with the exact 11-category enum from the agent definition
+
 ## [2.12.0] - 2026-04-27
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the **PSD Plugin Marketplace** — a multi-plugin marketplace for Claude Code and Claude Cowork, maintained by Peninsula School District.
 
-**Version**: 2.12.0
+**Version**: 2.13.0
 **Status**: Production-Ready
 
 ### Plugins

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Peninsula School District's plugin marketplace for Claude Code and Claude Cowork
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blue)](https://docs.claude.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/Version-2.12.0-green)]()
+[![Version](https://img.shields.io/badge/Version-2.13.0-green)]()
 
 ## Overview
 
 **Two independently installable plugins** — one for software development workflows, one for general productivity.
 
-**Version**: 2.12.0
+**Version**: 2.13.0
 
 ---
 

--- a/plugins/psd-coding-system/.claude-plugin/plugin.json
+++ b/plugins/psd-coding-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-coding-system",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "AI-assisted development system for Peninsula School District - workflow automation, specialized agents, memory-based learning, and Context7 framework docs",
   "author": {
     "name": "Kris Hagel",

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -2,7 +2,7 @@
 
 **Comprehensive AI-assisted development system for Peninsula School District**
 
-Version: 2.2.0
+Version: 2.3.0
 Status: Production-Ready Workflows + Memory-Based Learning
 Author: Kris Hagel (hagelk@psd401.net)
 

--- a/plugins/psd-coding-system/agents/workflow/learning-writer.md
+++ b/plugins/psd-coding-system/agents/workflow/learning-writer.md
@@ -12,6 +12,8 @@ color: yellow
 
 # Learning Writer Agent
 
+> **Why `background: true`?** Learnings must not block caller workflows (`/work`, `/test`, etc.). Silent failure risk is mitigated by robustness fixes: `mkdir -p` via Bash tool, write-by-default policy, and strict `[FILL:]` placeholder requirements in caller prompts.
+
 You are a lightweight learning capture agent. You receive a session summary from a workflow skill (/work, /test, /review-pr, /lfg, /debug, /optimize) and write a learning document. Your default action is to WRITE — only skip for genuine duplicates.
 
 **Context:** $ARGUMENTS
@@ -33,7 +35,7 @@ You receive a session summary containing:
 Always create the category directory first:
 
 ```bash
-mkdir -p docs/learnings/{CATEGORY}
+mkdir -p "docs/learnings/{CATEGORY}"
 ```
 
 Replace `{CATEGORY}` with the actual category value from the input (e.g., `docs/learnings/workflow/`).

--- a/plugins/psd-coding-system/agents/workflow/learning-writer.md
+++ b/plugins/psd-coding-system/agents/workflow/learning-writer.md
@@ -1,33 +1,44 @@
 ---
 name: learning-writer
 description: Automatic lightweight learning capture — deduplicates against existing learnings and writes to docs/learnings/
-tools: Read, Write, Grep, Glob
+tools: Bash, Read, Write, Grep, Glob
 model: claude-sonnet-4-6
 memory: project
 background: true
 keep-coding-instructions: true
-initialPrompt: "Process the session summary provided in $ARGUMENTS. Deduplicate against existing learnings in docs/learnings/, then write a new learning document if the insight is novel."
+initialPrompt: "Process the session summary provided in $ARGUMENTS. First run mkdir -p to ensure the target category directory exists under docs/learnings/. Then deduplicate against existing learnings. Default action is WRITE — only skip for genuine duplicates."
 color: yellow
 ---
 
 # Learning Writer Agent
 
-You are a lightweight learning capture agent. You receive a session summary from a workflow skill (/work, /test, /review-pr) and write a concise learning document if the insight is novel.
+You are a lightweight learning capture agent. You receive a session summary from a workflow skill (/work, /test, /review-pr, /lfg, /debug, /optimize) and write a learning document. Your default action is to WRITE — only skip for genuine duplicates.
 
 **Context:** $ARGUMENTS
 
 ## Inputs
 
 You receive a session summary containing:
-- `TRIGGER_REASON`: Why this learning was captured (e.g., "3+ errors encountered", "self-healing loop activated", "novel solution used")
 - `SUMMARY`: Brief description of what happened
 - `KEY_INSIGHT`: The specific learning or pattern discovered
-- `CATEGORY`: One of: build-errors, test-failures, runtime-errors, performance, security, database, ui, integration, logic, workflow
+- `CATEGORY`: One of: build-errors, test-failures, runtime-errors, performance, security, database, ui, integration, logic, workflow, debugging
 - `TAGS`: Comma-separated relevant tags
+
+**IMPORTANT**: Your default action is to WRITE a learning. Only skip if the insight is a genuine duplicate of an existing learning file. "Routine implementation" in KEY_INSIGHT still gets written — routine patterns are valuable for future reference.
 
 ## Workflow
 
-### Phase 1: Deduplication Check
+### Phase 1: Ensure Target Directory Exists
+
+Always create the category directory first:
+
+```bash
+mkdir -p docs/learnings/{CATEGORY}
+```
+
+Replace `{CATEGORY}` with the actual category value from the input (e.g., `docs/learnings/workflow/`).
+
+### Phase 2: Deduplication Check
 
 Search existing learnings to avoid duplicates:
 
@@ -35,11 +46,13 @@ Search existing learnings to avoid duplicates:
 Grep(pattern: "[key phrases from KEY_INSIGHT]", path: "./docs/learnings", glob: "*.md")
 ```
 
-If a substantially similar learning already exists:
+If a **substantially identical** learning already exists (same root cause AND same solution):
 - Report: "Duplicate detected — skipping write. Existing: [path]"
 - Exit without writing
 
-### Phase 2: Write Learning Document
+Similar but distinct learnings (same area, different root cause or solution) should still be written.
+
+### Phase 3: Write Learning Document
 
 Create a new learning file at `docs/learnings/{CATEGORY}/{date}-{slug}.md`:
 
@@ -50,7 +63,7 @@ category: [CATEGORY]
 tags: [TAGS as YAML list]
 severity: [critical|high|medium|low — based on impact]
 date: [YYYY-MM-DD]
-source: [auto — /work|/test|/review-pr]
+source: [auto — /work|/test|/review-pr|/lfg|/debug|/optimize]
 applicable_to: project
 ---
 
@@ -71,7 +84,7 @@ applicable_to: project
 [How to avoid this in the future]
 ```
 
-### Phase 3: Confirm
+### Phase 4: Confirm
 
 Report what was written:
 - File path
@@ -81,14 +94,15 @@ Report what was written:
 
 ## Rules
 
+- **Default is to write** — only skip for genuine duplicates, never for "seems routine"
 - **Be concise** — learnings should be 10-20 lines, not essays
 - **Be specific** — include file paths, error messages, or code patterns when relevant
 - **No fabrication** — only write what actually happened in the session
-- **Skip trivial** — if the insight is obvious or low-value, skip it and explain why
-- Ensure `docs/learnings/{CATEGORY}/` directory exists before writing (create if needed)
+- **Always mkdir -p first** — the category directory may not exist yet
 
 ## Success Criteria
 
+- Category directory created (mkdir -p)
 - Deduplicated against existing learnings
 - Learning written in standard format with valid frontmatter
 - Concise and actionable

--- a/plugins/psd-coding-system/skills/debug/SKILL.md
+++ b/plugins/psd-coding-system/skills/debug/SKILL.md
@@ -277,11 +277,11 @@ SYMPTOM: [observed behavior]
 
 ## Phase 8: Learning Capture (Task-Delegated — Always)
 
-Always dispatch the learning-writer agent. Debug sessions produce high-value learnings — root cause patterns, misleading symptoms, and diagnostic techniques.
+Always dispatch the learning-writer agent. Debug sessions produce high-value learnings — root cause patterns, misleading symptoms, and diagnostic techniques. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture learning from debug session"
-- prompt: "SUMMARY=[debug session: symptom was X, root cause was Y, fix was Z, hypotheses tested: N confirmed / M refuted] KEY_INSIGHT=[the most notable diagnostic technique or root cause pattern from this session, or 'routine bug fix' if nothing stood out] CATEGORY=[debugging] TAGS=[debug, root-cause-analysis, relevant-tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: debug session — symptom, root cause, fix, hypotheses tested] KEY_INSIGHT=[FILL: the most notable diagnostic technique or root cause pattern from this session] CATEGORY=debugging TAGS=[FILL: debug, root-cause-analysis, plus relevant tags]. Write the learning document."
 
 **Do not block on this agent** — the fix is already committed.
 

--- a/plugins/psd-coding-system/skills/lfg/SKILL.md
+++ b/plugins/psd-coding-system/skills/lfg/SKILL.md
@@ -275,11 +275,11 @@ If no findings at any severity, skip this phase.
 
 ## Phase 10: Learning Capture (Task-Delegated — Always)
 
-Always dispatch the learning-writer agent with a session summary. The agent handles deduplication and novelty detection — it will skip writing if the insight isn't novel.
+Always dispatch the learning-writer agent with a session summary. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture learning from /lfg session"
-- prompt: "SUMMARY=[end-to-end session: implementation approach, errors encountered, test results, review findings, fixes applied] KEY_INSIGHT=[the most notable learning from this autonomous session, or 'routine implementation' if nothing stood out] CATEGORY=[appropriate category] TAGS=[lfg, autonomous, relevant-tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: end-to-end session — implementation approach, errors encountered, test results, review findings, fixes applied] KEY_INSIGHT=[FILL: the most notable learning from this autonomous session] CATEGORY=[FILL: one of build-errors, test-failures, runtime-errors, performance, security, database, ui, integration, logic, workflow, debugging] TAGS=[FILL: lfg, autonomous, plus relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, the PR is already created and pushed.
 

--- a/plugins/psd-coding-system/skills/optimize/SKILL.md
+++ b/plugins/psd-coding-system/skills/optimize/SKILL.md
@@ -524,11 +524,11 @@ List hypotheses that were not tested (if any remain from the ranked list):
 
 ## Phase 6: Learning Capture (Task-Delegated — Always)
 
-Always dispatch the learning-writer agent with a session summary.
+Always dispatch the learning-writer agent with a session summary. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture learning from /optimize session"
-- prompt: "SUMMARY=[optimization target: $ARGUMENTS, baseline: $BASELINE, final: $CURRENT_BEST, improvement: ${TOTAL_IMPROVEMENT}%, experiments: $ITERATION, hypotheses tested and outcomes] KEY_INSIGHT=[the most effective optimization technique from this session, or 'routine optimization' if nothing stood out] CATEGORY=performance TAGS=[optimize, metrics, iterative-improvement]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: optimization target, baseline metric, final metric, improvement %, experiments run, hypotheses tested and outcomes] KEY_INSIGHT=[FILL: the most effective optimization technique from this session] CATEGORY=performance TAGS=[FILL: optimize, metrics, iterative-improvement, plus relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, the optimization is already applied.
 

--- a/plugins/psd-coding-system/skills/review-pr/SKILL.md
+++ b/plugins/psd-coding-system/skills/review-pr/SKILL.md
@@ -678,11 +678,11 @@ echo "PR review completed successfully!"
 
 ### Phase 6: Learning Capture
 
-Always dispatch the learning-writer agent with a session summary. The agent handles deduplication and novelty detection — it will skip writing if the insight isn't novel.
+Always dispatch the learning-writer agent with a session summary. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture PR review learning for #$PR_NUMBER"
-- prompt: "SUMMARY=[Round $REVIEW_ROUND review of PR #$PR_NUMBER. $(if [ "$INCREMENTAL" = true ]; then echo "Incremental run — only new feedback since Round $PREV_ROUND."; else echo "Full review — first pass."; fi) What review patterns were found, severity breakdown, agents invoked] KEY_INSIGHT=[the most notable mistake pattern or prevention strategy from this session, or 'routine review' if nothing stood out] CATEGORY=[appropriate category — e.g., security, logic, integration] TAGS=[relevant tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: Round $REVIEW_ROUND review of PR #$PR_NUMBER — what review patterns were found, severity breakdown, agents invoked] KEY_INSIGHT=[FILL: the most notable mistake pattern or prevention strategy from this session] CATEGORY=[FILL: one of security, logic, integration, workflow, etc.] TAGS=[FILL: comma-separated relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, proceed without learning capture.
 

--- a/plugins/psd-coding-system/skills/review-pr/SKILL.md
+++ b/plugins/psd-coding-system/skills/review-pr/SKILL.md
@@ -682,7 +682,7 @@ Always dispatch the learning-writer agent with a session summary. **You MUST fil
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture PR review learning for #$PR_NUMBER"
-- prompt: "SUMMARY=[FILL: Round $REVIEW_ROUND review of PR #$PR_NUMBER — what review patterns were found, severity breakdown, agents invoked] KEY_INSIGHT=[FILL: the most notable mistake pattern or prevention strategy from this session] CATEGORY=[FILL: one of security, logic, integration, workflow, etc.] TAGS=[FILL: comma-separated relevant tags]. Write the learning document."
+- prompt: "SUMMARY=[FILL: Round $REVIEW_ROUND review of PR #$PR_NUMBER — what review patterns were found, severity breakdown, agents invoked] KEY_INSIGHT=[FILL: the most notable mistake pattern or prevention strategy from this session] CATEGORY=[FILL: one of build-errors, test-failures, runtime-errors, performance, security, database, ui, integration, logic, workflow, debugging] TAGS=[FILL: comma-separated relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, proceed without learning capture.
 

--- a/plugins/psd-coding-system/skills/test/SKILL.md
+++ b/plugins/psd-coding-system/skills/test/SKILL.md
@@ -221,11 +221,11 @@ echo "Testing completed successfully!"
 
 ### Phase 6: Learning Capture
 
-Always dispatch the learning-writer agent with a session summary. The agent handles deduplication and novelty detection — it will skip writing if the insight isn't novel.
+Always dispatch the learning-writer agent with a session summary. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture testing learning"
-- prompt: "SUMMARY=[what test issues were encountered, self-healing attempts, coverage findings] KEY_INSIGHT=[the most notable testing pattern or failure mode from this session, or 'routine testing' if nothing stood out] CATEGORY=test-failures TAGS=[relevant tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: what test issues were encountered, self-healing attempts, coverage findings] KEY_INSIGHT=[FILL: the most notable testing pattern or failure mode from this session] CATEGORY=test-failures TAGS=[FILL: comma-separated relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, proceed without learning capture.
 

--- a/plugins/psd-coding-system/skills/work/SKILL.md
+++ b/plugins/psd-coding-system/skills/work/SKILL.md
@@ -305,10 +305,10 @@ echo "=== PR created ==="
 
 ## Phase 7: Learning Capture
 
-Always dispatch the learning-writer agent with a session summary. The agent handles deduplication and novelty detection — it will skip writing if the insight isn't novel.
+Always dispatch the learning-writer agent with a session summary. **You MUST fill in the bracketed placeholders below with actual data from this session** — do not pass the template text literally.
 
 - subagent_type: "psd-coding-system:workflow:learning-writer"
 - description: "Capture learning from #$ISSUE_NUMBER"
-- prompt: "SUMMARY=[brief description of what happened during implementation — errors hit, patterns used, workarounds applied] KEY_INSIGHT=[the most notable learning or pattern from this session, or 'routine implementation' if nothing stood out] CATEGORY=[appropriate category] TAGS=[relevant tags]. Write a concise learning document only if this insight is novel. Skip if routine."
+- prompt: "SUMMARY=[FILL: describe what happened — errors hit, patterns used, workarounds applied] KEY_INSIGHT=[FILL: the most notable learning or pattern from this session] CATEGORY=[FILL: one of build-errors, test-failures, runtime-errors, performance, security, database, ui, integration, logic, workflow, debugging] TAGS=[FILL: comma-separated relevant tags]. Write the learning document."
 
 **Do not block on this agent** — if it fails, proceed without learning capture.


### PR DESCRIPTION
## Summary
Implements #57 — the learning-writer agent was producing 0 output in consuming repos. Over a 14-day window in `psd401/aistudio`, 161 commits landed but `docs/learnings/` contained 0 files.

## Root Causes Identified & Fixed

1. **Missing Bash tool** — agent had `tools: Read, Write, Grep, Glob` but no `Bash`, preventing `mkdir -p` for category directories. Write tool fails silently when target directory doesn't exist.

2. **Input schema mismatch** — agent expected `TRIGGER_REASON` field that no skill ever sent. Stale field from an earlier design.

3. **"Skip if routine" escape hatch** — every skill prompt ended with "Skip if routine" which, combined with template placeholder text sometimes being passed literally, caused the agent to skip nearly every invocation.

4. **Silent failure masking** — `background: true` + "do not block" meant all failures were invisible. No feedback loop to detect breakage. **Mitigation (not removal):** `background: true` is retained intentionally — learnings must not block user-facing workflows like `/work` or `/test`. Instead, robustness fixes (mkdir-p with Bash tool, write-by-default policy, strict placeholder requirements) reduce the likelihood of silent failures. A future enhancement could add lightweight observability (e.g., a log line on failure), but removing background mode would degrade the user experience.

## Changes

### Agent (`learning-writer.md`)
- Added `Bash` to tools list (enables `mkdir -p`)
- Removed stale `TRIGGER_REASON` from expected inputs
- Added Phase 1: `mkdir -p` directory creation before any write attempt
- Quoted `mkdir -p` path to handle special characters in category names
- Changed dedup threshold from "substantially similar" to "substantially identical (same root cause AND same solution)"
- Added `debugging` to valid CATEGORY list
- Added `/lfg`, `/debug`, `/optimize` to source field options
- Strengthened default-to-write language throughout
- Updated `initialPrompt` to assert mkdir-p-first and write-by-default
- Added inline comment explaining why `background: true` is retained

### Skills (6 files: work, test, review-pr, lfg, debug, optimize)
- Removed "Skip if routine" from all dispatch prompts
- Added `[FILL:]` prefix to all template placeholders to signal required substitution
- Added bold instruction: "You MUST fill in the bracketed placeholders with actual data"
- Changed final instruction from conditional to unconditional "Write the learning document"
- Fixed CATEGORY list in review-pr to match the agent's documented allowed categories verbatim

## Completion Criteria
- [x] Unit and integration tests pass (N/A — markdown-only plugin, no test suite)
- [x] E2E tests pass — flows: N/A — plugin is markdown instructions consumed by Claude Code runtime; manual verification requires running `/work` against a real issue in a consuming repo
- [x] Zero lint warnings on every touched file (N/A — all `.md` files, no markdown linter configured)
- [x] Type check clean (N/A — no TypeScript in changes)

## Touched Files
- plugins/psd-coding-system/agents/workflow/learning-writer.md
- plugins/psd-coding-system/skills/debug/SKILL.md
- plugins/psd-coding-system/skills/lfg/SKILL.md
- plugins/psd-coding-system/skills/optimize/SKILL.md
- plugins/psd-coding-system/skills/review-pr/SKILL.md
- plugins/psd-coding-system/skills/test/SKILL.md
- plugins/psd-coding-system/skills/work/SKILL.md

## Verification

To verify the fix works, run `/work` against a small issue in a consuming repo after merging and confirm a file appears in `docs/learnings/`.

Closes #57