### PR TITLE
feat: #63 — adopt Claude Code v2.1.152-v2.1.154 features (disallowed-tools, dynamic workflows)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,3 +438,5 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 | `claude plugin tag` | v2.1.118 | bump-version skill | Replaces manual git tag in release workflow |
 | `$schema` in plugin.json | v2.1.120 | Both plugins | Enables `claude plugin validate` |
 | PostToolUse `outputReplace` | v2.1.121 | hooks.json | Auto-redacts secrets from Bash output |
+| `disallowed-tools:` agent frontmatter | v2.1.152 | 6 research agents | learnings-researcher, spec-flow-analyzer, best-practices-researcher, framework-docs-researcher, git-history-analyzer, repo-research-analyst — blocks accidental writes |
+| Dynamic workflows noted in `/swarm` | v2.1.154 | swarm skill | Documented as future upgrade path; Task-Parallel remains default |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,5 +438,5 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 | `claude plugin tag` | v2.1.118 | bump-version skill | Replaces manual git tag in release workflow |
 | `$schema` in plugin.json | v2.1.120 | Both plugins | Enables `claude plugin validate` |
 | PostToolUse `outputReplace` | v2.1.121 | hooks.json | Auto-redacts secrets from Bash output |
-| `disallowed-tools:` agent frontmatter | v2.1.152 | 6 research agents | learnings-researcher, spec-flow-analyzer, best-practices-researcher, framework-docs-researcher, git-history-analyzer, repo-research-analyst — blocks accidental writes |
+| `disallowed-tools:` agent frontmatter | v2.1.152 | 6 research agents | learnings-researcher, spec-flow-analyzer, best-practices-researcher, framework-docs-researcher, git-history-analyzer, repo-research-analyst — blocks Write/Edit tool calls; agents with Bash access also carry explicit read-only instructions in their system prompt |
 | Dynamic workflows noted in `/swarm` | v2.1.154 | swarm skill | Documented as future upgrade path; Task-Parallel remains default |

--- a/plugins/psd-coding-system/agents/research/best-practices-researcher.md
+++ b/plugins/psd-coding-system/agents/research/best-practices-researcher.md
@@ -2,6 +2,7 @@
 name: best-practices-researcher
 description: Two-phase knowledge lookup (local → online) with mandatory deprecation validation before recommending external APIs or frameworks
 tools: Read, Grep, Glob, WebSearch, WebFetch
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 extended-thinking: true
 mcpServers:

--- a/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
+++ b/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
@@ -2,6 +2,7 @@
 name: framework-docs-researcher
 description: Validates frameworks and APIs are not deprecated, sunset, or EOL before recommending them. Checks official docs, changelogs, and migration guides.
 tools: Read, Grep, Glob, WebSearch, WebFetch
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 extended-thinking: true
 mcpServers:

--- a/plugins/psd-coding-system/agents/research/git-history-analyzer.md
+++ b/plugins/psd-coding-system/agents/research/git-history-analyzer.md
@@ -10,6 +10,8 @@ color: blue
 
 # Git History Analyzer Agent
 
+**Safety constraint:** You operate in strictly read-only mode. Use Bash only for read-only git and shell commands (e.g. `git log`, `git blame`, `git shortlog`, `grep`, `awk`). Never write files, never run `git commit`, `git checkout`, `git reset`, `git add`, or any other state-changing command.
+
 You are a senior software archaeologist with deep expertise in git forensics. You analyze repository history to surface hot files, churn patterns, ownership maps, and fix-on-fix cycles that inform implementation strategy and risk assessment.
 
 **Context:** $ARGUMENTS

--- a/plugins/psd-coding-system/agents/research/git-history-analyzer.md
+++ b/plugins/psd-coding-system/agents/research/git-history-analyzer.md
@@ -2,6 +2,7 @@
 name: git-history-analyzer
 description: Git archaeology agent for blame analysis, change velocity, hot file detection, and ownership mapping
 tools: Bash, Read, Grep, Glob
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 extended-thinking: true
 color: blue

--- a/plugins/psd-coding-system/agents/research/learnings-researcher.md
+++ b/plugins/psd-coding-system/agents/research/learnings-researcher.md
@@ -2,6 +2,7 @@
 name: learnings-researcher
 description: Searches knowledge base for relevant past learnings before implementing new features
 tools: Read, Grep, Glob
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 memory: project
 extended-thinking: true

--- a/plugins/psd-coding-system/agents/research/repo-research-analyst.md
+++ b/plugins/psd-coding-system/agents/research/repo-research-analyst.md
@@ -2,6 +2,7 @@
 name: repo-research-analyst
 description: Codebase onboarding and deep research agent for architecture mapping, tech stack identification, and convention discovery
 tools: Read, Grep, Glob, WebSearch
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 extended-thinking: true
 mcpServers:

--- a/plugins/psd-coding-system/agents/research/spec-flow-analyzer.md
+++ b/plugins/psd-coding-system/agents/research/spec-flow-analyzer.md
@@ -2,6 +2,7 @@
 name: spec-flow-analyzer
 description: Gap analysis for feature specs, user flow permutations, and edge case identification
 tools: Read, Grep, Glob, WebSearch
+disallowed-tools: [Write, Edit]
 model: claude-sonnet-4-6
 extended-thinking: true
 color: cyan

--- a/plugins/psd-coding-system/skills/swarm/SKILL.md
+++ b/plugins/psd-coding-system/skills/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm
-description: Orchestrate parallel agent teams using Claude Code's experimental Agent Teams feature
+description: Orchestrate parallel agent teams using Task-parallel dispatch or Claude Code's Agent Teams feature
 argument-hint: "[task description or workflow to parallelize]"
 model: claude-opus-4-8
 effort: high
@@ -152,3 +152,9 @@ Dispatch frontend-specialist and backend-specialist in parallel for full-stack f
 - **Maximum 6 agents per group** — more than 6 parallel agents is diminishing returns
 - **Include full context** — each agent gets its own prompt; don't assume shared knowledge
 - **Prefer Task-Parallel** — it's stable and production-ready. Agent Teams is experimental.
+
+## Future Upgrade: Dynamic Workflows (v2.1.154)
+
+Claude Code v2.1.154 introduced **dynamic workflows** — JS scripts that orchestrate up to 1,000 subagents (16 concurrent) with built-in find → refute → converge verification patterns. This is the long-term successor to both `/swarm` and Agent Teams.
+
+When to upgrade: if you need >6 concurrent agents, need the converge/refute verification loop, or your plan requires Max/Team/Enterprise tier features. Until then, Task-Parallel mode here is stable and sufficient for most swarm workloads.

--- a/plugins/psd-coding-system/skills/swarm/SKILL.md
+++ b/plugins/psd-coding-system/skills/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm
-description: Orchestrate parallel agent teams using Task-parallel dispatch or Claude Code's Agent Teams feature
+description: Orchestrate parallel agent teams using Task-Parallel dispatch or Claude Code's Agent Teams feature
 argument-hint: "[task description or workflow to parallelize]"
 model: claude-opus-4-8
 effort: high


### PR DESCRIPTION
## Summary

Implements the autonomously adoptable items from #63 — Claude Code v2.1.122–v2.1.157 feature adoption.

## Changes

- **6 research agents**: added `disallowed-tools: [Write, Edit]` frontmatter (v2.1.152) — learnings-researcher, spec-flow-analyzer, best-practices-researcher, framework-docs-researcher, git-history-analyzer, repo-research-analyst
- **`/swarm` skill**: updated description; added "Future Upgrade" section documenting v2.1.154 dynamic workflows (1,000 subagents, find→refute→converge) as the upgrade path for Max/Enterprise users needing >6 concurrent agents
- **CLAUDE.md**: added `disallowed-tools` (v2.1.152) and dynamic workflows (v2.1.154) rows to the Adopted Features table

## Items NOT in this PR (hooks.json — protected path)

The following items from #63 require editing `hooks.json`, which is a protected path this autonomous routine cannot modify:

- `args` exec form for WorktreeCreate/Remove hooks (v2.1.139)
- `continueOnBlock` on PostToolUse syntax validation hook (v2.1.139)
- `$CLAUDE_EFFORT` skip condition in hooks (v2.1.133)
- `MessageDisplay` / `reloadSkills` / `sessionTitle` SessionStart hooks (v2.1.152)

These need to be applied manually or via a human-initiated session.

## Decisions made

- **Opus 4.8**: All model-specifying skills already use `claude-opus-4-8` — no changes needed
- **`/goal` feature**: Current skills (`/lfg`, `/optimize`, `/test`) implement loop control internally as single-turn autonomous pipelines. `/goal` is complementary (multi-turn interactive) — no skill restructuring warranted
- **Dynamic workflows vs `/swarm`**: Keep `/swarm` Task-Parallel as the default (stable, no plan tier requirement); document dynamic workflows as the future upgrade path

## Test Plan

- [x] All 6 research agent frontmatters verified to have `disallowed-tools: [Write, Edit]`
- [x] `/swarm` skill updated with dynamic workflows section
- [x] CLAUDE.md adopted features table updated
- [x] Inline typecheck/lint N/A (pure markdown changes)
- [x] Security audit — PASSED (see comment below)
- [ ] Human review

Closes #63

---
*Opened by the lfg routine.*