### PR TITLE
fix(evolve): fix release-check source, add Tier 1 command detection, add CE changelog delta (#65)

### DIFF
--- a/plugins/psd-coding-system/skills/evolve/SKILL.md
+++ b/plugins/psd-coding-system/skills/evolve/SKILL.md
@@ -84,7 +84,7 @@ CUTOFF_DATE=$(date -v-90d +"%Y-%m-%d" 2>/dev/null || date -d "90 days ago" +"%Y-
 EXPIRED_COUNT=0
 for f in $(find "$PLUGIN_DIR/docs/learnings" -name "*.md" -not -name ".gitkeep" -type f 2>/dev/null); do
   FILE_DATE=$(grep -m1 "^date:" "$f" 2>/dev/null | sed 's/^date: *//')
-  if [ -n "$FILE_DATE" ] && [[ "$FILE_DATE" < "$CUTOFF_DATE" ]]; then
+  if [ -n "$FILE_DATE" ] && [["$FILE_DATE" < "$CUTOFF_DATE"]]; then
     rm "$f"
     EXPIRED_COUNT=$((EXPIRED_COUNT + 1))
   fi
@@ -250,27 +250,57 @@ Present the meta-reviewer's report with:
 
 Use WebFetch to check for Claude Code updates:
 
-1. Fetch `https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md` — extract recent versions
-2. Compare against our plugin structure:
-   - Check for new frontmatter fields we should adopt
-   - Check for new hook events
-   - Check for new tool permissions
-   - Check for model deprecations
-   - Check for breaking changes
+1. **Primary source** — Fetch `https://code.claude.com/docs/en/changelog` (canonical, always current; the GitHub blob was lossy and stale)
+2. **Secondary cross-check** — Fetch `https://github.com/anthropics/claude-code/releases` to confirm version dates and fill any gaps from the primary source
+3. Compare against our plugin structure using a **significance-ranked checklist**:
+
+   **Tier 1 — Headline features (MANDATORY: list ALL, even if no adoption recommended this cycle):**
+   - New slash commands (e.g. `/goal`, `/session`)
+   - New CLI subcommands (e.g. `claude session`, `claude plugin tag`)
+   - New orchestration or agent execution models (e.g. dynamic workflows, headless mode, multi-agent)
+   - New top-level capabilities that change how plugins or sessions fundamentally work
+
+   **Tier 2 — Adoption candidates:**
+   - New frontmatter fields for skills/agents (`effort:`, `paths:`, `keep-coding-instructions:`, `initialPrompt:`, etc.)
+   - New hook events (`PreCompact`, `WorktreeCreate/Remove`, etc.)
+   - New tool permissions or scoping mechanisms
+   - New `$schema` or plugin validation tooling
+
+   **Tier 3 — Maintenance checks:**
+   - Model deprecations or renames
+   - Breaking changes to existing APIs or hook formats
+   - Bug fixes relevant to known plugin issues
+
+**CRITICAL:** The release report MUST explicitly list every new top-level slash command and every new orchestration paradigm shipped since `last_updates_check`, even if no adoption action is recommended. Omitting a shipped command (e.g. `/goal`, dynamic workflows) is a miss — the checklist existed precisely to catch these.
 
 Present a structured report:
 ```markdown
 ### Claude Code Release Analysis
 
-| Version | Key Changes | Impact on Plugin |
-|---------|-------------|-----------------|
-| X.Y.Z   | ...         | ...             |
+**Tier 1 — New Commands & Orchestration (ALL must be listed)**
+
+| Command / Feature | Version | Description | Adopt? |
+|------------------|---------|-------------|--------|
+| /goal            | v2.1.139 | ...         | Yes/No/Later |
+| dynamic workflows | v2.1.154 | ...        | Yes/No/Later |
+
+**Tier 2 — Adoption Candidates**
+
+| Feature | Version | Impact on Plugin |
+|---------|---------|------------------|
+| ...     | ...     | ...              |
+
+**Tier 3 — Maintenance**
+
+| Version | Change | Action Required |
+|---------|--------|-----------------|
+| X.Y.Z   | ...    | ...             |
 
 ### Required Actions
-- [List any breaking changes]
+- [List any breaking changes or urgent adoption items]
 
 ### Recommended Improvements
-- [List new features we should adopt]
+- [List Tier 1 + Tier 2 features to adopt, ranked by impact]
 ```
 
 ### Phase 3C: Pattern Contribution
@@ -302,11 +332,21 @@ Use WebFetch to analyze Every's Compound Engineering plugin:
 
 1. Fetch `https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/README.md`
 2. Fetch `https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/plugins/compound-engineering/.claude-plugin/plugin.json`
-3. Compare agent counts, skill patterns, architecture approaches
+3. Fetch `https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/CHANGELOG.md` — CE publishes canonical release notes here (the root CHANGELOG links to GitHub Releases for tagged entries)
+4. **Filter CE CHANGELOG to entries after `last_compare`** — only compare what is NEW since the last run, not a full snapshot each time. If `last_compare` is null, report all entries.
+5. Compare agent counts, skill patterns, architecture approaches, and new features added since last check
 
 Present a structured comparison:
 ```markdown
 ### Plugin Comparison: PSD vs Every
+
+**CE changes since last compare (`last_compare` date)**
+
+| Version / Entry | CE Change | Relevant to PSD? |
+|----------------|-----------|------------------|
+| ...            | ...       | Yes/No           |
+
+**Overall Snapshot**
 
 | Dimension | PSD | Every | Gap |
 |-----------|-----|-------|-----|

--- a/plugins/psd-coding-system/skills/evolve/SKILL.md
+++ b/plugins/psd-coding-system/skills/evolve/SKILL.md
@@ -84,7 +84,7 @@ CUTOFF_DATE=$(date -v-90d +"%Y-%m-%d" 2>/dev/null || date -d "90 days ago" +"%Y-
 EXPIRED_COUNT=0
 for f in $(find "$PLUGIN_DIR/docs/learnings" -name "*.md" -not -name ".gitkeep" -type f 2>/dev/null); do
   FILE_DATE=$(grep -m1 "^date:" "$f" 2>/dev/null | sed 's/^date: *//')
-  if [ -n "$FILE_DATE" ] && [["$FILE_DATE" < "$CUTOFF_DATE"]]; then
+  if [ -n "$FILE_DATE" ] && [[ "$FILE_DATE" < "$CUTOFF_DATE" ]]; then
     rm "$f"
     EXPIRED_COUNT=$((EXPIRED_COUNT + 1))
   fi


### PR DESCRIPTION
## Summary

Fixes three structural defects in `/evolve` that caused the 2026-05-29 miss of `/goal` (v2.1.139) and dynamic workflows (v2.1.154).

- **Defect 1 (Changelog source)** — Phase 3B was fetching `github.com/anthropics/claude-code/blob/main/CHANGELOG.md`, a lossy GitHub blob render. Changed primary source to `https://code.claude.com/docs/en/changelog` (canonical, always current). GitHub releases page kept as secondary cross-check.
- **Defect 2 (Missing command/orchestration detection)** — Phase 3B checklist only covered frontmatter fields, hook events, tool permissions, and model deprecations. New slash commands and orchestration paradigms fell outside every category, making them structurally invisible. Added significance-ranked Tier 1 (headline features: new slash commands, CLI subcommands, orchestration models) that is MANDATORY — all new commands must be listed even when no adoption is recommended. Tier 2 covers adoption candidates; Tier 3 covers maintenance.
- **Defect 3 (CE snapshot vs delta)** — Phase 3D only fetched CE README + plugin.json, producing a count-based comparison with no sense of what changed. Added CE CHANGELOG fetch (step 3) and filter to entries after `last_compare` (step 4) so comparison shows only what is NEW since the last run.

## Changes

- `plugins/psd-coding-system/skills/evolve/SKILL.md` — Phase 3B and Phase 3D sections updated

## Test Plan

- [x] Phase 3B now fetches from `code.claude.com/docs/en/changelog` (canonical)
- [x] Phase 3B Tier 1 requirement mandates listing ALL new slash commands and orchestration models
- [x] Phase 3B structured report template leads with Tier 1 table
- [x] Phase 3D fetches CE CHANGELOG as step 3
- [x] Phase 3D filters CE entries to `> last_compare` timestamp
- [x] All other phases and skill logic unchanged
- [x] Security audit passed
- [ ] Human review

Closes #65

---
*Opened by the lfg routine.*