### PR TITLE
chore(agents): migrate all agents to Claude Sonnet 5 + fix stale model-ID docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "PSD Plugin Marketplace for Claude Code and Claude Cowork — coding workflows, productivity agents, and district automation",
-    "version": "2.18.0",
+    "version": "2.19.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "name": "psd-coding-system",
       "source": "./plugins/psd-coding-system",
       "description": "AI-assisted development system — 3 disciplined surfaces (/plan, /lfg, /evolve), verification-first run-to-100%-clean PR loop, specialized agents, memory-based learning, and Context7 framework docs",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "category": "productivity",
       "keywords": [
         "workflow",
@@ -32,7 +32,7 @@
       "name": "psd-productivity",
       "source": "./plugins/psd-productivity",
       "description": "36 productivity workflows + 1 agent — ParentSquare district data CLI, beautiful HTML artifact generation (incl. self-contained data dashboards & charts), board policy formatting, DocuSign migration/export, PDF Builder, Documenso document signing, n8n workflow automation, document generation, research, TTS, enrollment automation, browser control, Google Workspace, and district operations",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "category": "productivity",
       "keywords": [
         "productivity",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **GitHub label taxonomy** documented per routine and pre-created across all three target repos: `triaged-from-freshservice`; `lfg-ready` / `lfg-in-progress` / `lfg-pr-open` / `lfg-blocked` / `lfg-skip`; `pr-fix-stuck` / `pr-fix-done` / `pr-fix-skip`. Designed for mobile-tap workflows from GitHub's app.
   - **Pattern 1 validation pilot** at `routine-pilots/agent-discovery-check/` (since removed after validation) — confirmed via pilot fires that project-scope `.claude/agents/*.md` AND user-scope `~/.claude/agents/*.md` written by setup are auto-discovered at routine session start, and the env setup script re-runs on every fire with a fresh HOME.
 
+## [2.19.0] - 2026-06-30
+
+### Changed
+- **All 41 agents migrated to Claude Sonnet 5** (`model: claude-sonnet-4-6` → `claude-sonnet-5`) — 40 in psd-coding-system, plus psd-productivity's `enrollment-validator`. Sonnet 5 supports the `effort` parameter (`low`/`medium`/`high`/`xhigh`/`max`), so the old Sonnet-4.6 effort-rejection blocker (GitHub issue #30795) no longer applies. The four heavy agents (`runtime-verifier`, `meta-reviewer`, `architect-specialist`, `plan-validator`) stay on `claude-opus-4-8`.
+- Version bumps: **psd-coding-system 3.0.0 → 3.1.0**, **psd-productivity 2.15.0 → 2.15.1**, **marketplace 2.18.0 → 2.19.0**.
+
+### Fixed
+- **Stale model-ID convention.** `agents/validation/configuration-validator.md` previously taught "append a date suffix (`claude-sonnet-4-6-20250929`)" as the correct standard — reversed to the current convention: the **bare alias** `claude-sonnet-5` with **no date suffix** (a date-suffixed Sonnet alias 404s); its validation example now flags date-suffixed IDs as the error.
+- Refreshed illustrative model references in `agent-native-reviewer.md` and the CLAUDE.md "Model Selection" rules/strategy to `claude-sonnet-5` (agents default to Sonnet 5; skills still default to `claude-opus-4-8`). Historical CHANGELOG entries left at their original values.
+
 ## [2.18.0] - 2026-06-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the **PSD Plugin Marketplace** — a multi-plugin marketplace for Claude Code and Claude Cowork, maintained by Peninsula School District.
 
-**Version**: 2.18.0
+**Version**: 2.19.0
 **Status**: Production-Ready
 
 ### Plugins
@@ -401,7 +401,7 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 - PreCompact hook preserves branch/task context during compaction
 
 ### Model Selection Strategy
-- **sonnet-4-6**: Default for agents and lightweight coding tasks
+- **sonnet-5**: Default for agents and lightweight coding tasks
 - **opus-4-8**: All skills that specify `model:` in frontmatter
 - **effort: high**: Default for most skills/agents
 - **effort: xhigh**: Heavy-lifting skills: `/architect`, `/product-manager`, `/lfg`, `/evolve`, meta-reviewer agent (v2.1.111)
@@ -410,13 +410,13 @@ Each plugin version tracks breaking changes for users of *that specific plugin* 
 
 ### Model Selection Rules for Skills
 
-**Rule**: If a skill specifies `model:` in frontmatter, use `claude-opus-4-8` with `effort: high` (or `xhigh` for heavy-lifting skills). Never specify `model: claude-sonnet-4-6` in skill frontmatter while the Claude Code default is Opus 4.8.
+**Rule**: If a skill specifies `model:` in frontmatter, use `claude-opus-4-8` with `effort: high` (or `xhigh` for heavy-lifting skills). Skills default to Opus 4.8; agents run on `claude-sonnet-5`.
 
-**Why**: Claude Code v2.1.68+ unconditionally sends the effort parameter to all model invocations. Opus 4.8 supports effort; Sonnet 4.6 does not. Skills specifying sonnet receive this unsupported parameter → API error. GitHub issue #30795 (open as of 2026-03-15).
+**Why**: Claude Code v2.1.68+ unconditionally sends the effort parameter to all model invocations. **Sonnet 5 supports effort** (`low`/`medium`/`high`/`xhigh`/`max`), so the old Sonnet 4.6 blocker (GitHub issue #30795 — Sonnet 4.6 rejected `effort`) no longer applies. Agents were moved to `claude-sonnet-5` for this reason. Skills still default to `claude-opus-4-8` for consistency.
 
 **Lightweight skills** (changelog, triage, bump-version, etc.) that don't specify a model inherit the default (currently Opus 4.8) and are safe.
 
-**If you want to use Sonnet in a skill**: Remove the `model:` field entirely and let it inherit the default. Do NOT explicitly specify `model: claude-sonnet-4-6` until issue #30795 is resolved.
+**If you want to use Sonnet in a skill**: `claude-sonnet-5` is safe (it supports `effort`), but the project default remains `claude-opus-4-8` — either set `model: claude-sonnet-5` explicitly or omit `model:` to inherit the Opus default.
 
 ### Adopted Claude Code Features
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Peninsula School District's plugin marketplace for Claude Code and Claude Cowork
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blue)](https://docs.claude.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/Version-2.18.0-green)]()
+[![Version](https://img.shields.io/badge/Version-2.19.0-green)]()
 
 ## Overview
 
 **Two independently installable plugins** — one for software development workflows, one for general productivity.
 
-**Version**: 2.18.0
+**Version**: 2.19.0
 
 ---
 

--- a/plugins/psd-coding-system/.claude-plugin/plugin.json
+++ b/plugins/psd-coding-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-coding-system",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "AI-assisted development system for Peninsula School District - workflow automation, specialized agents, memory-based learning, and Context7 framework docs",
   "author": {
     "name": "Kris Hagel",

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -2,7 +2,7 @@
 
 **Comprehensive AI-assisted development system for Peninsula School District**
 
-Version: 3.0.0
+Version: 3.1.0
 Status: Production-Ready Workflows + Memory-Based Learning
 Author: Kris Hagel (hagelk@psd401.net)
 

--- a/plugins/psd-coding-system/agents/domain/backend-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/backend-specialist.md
@@ -2,7 +2,7 @@
 name: backend-specialist
 description: Backend development specialist for APIs, server logic, and system integration
 tools: Read, Edit, Write
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: blue
 ---

--- a/plugins/psd-coding-system/agents/domain/database-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/database-specialist.md
@@ -2,7 +2,7 @@
 name: database-specialist
 description: Database specialist for schema design, query optimization, and data migrations
 tools: Read, Edit, Write
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: yellow
 ---

--- a/plugins/psd-coding-system/agents/domain/frontend-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/frontend-specialist.md
@@ -2,7 +2,7 @@
 name: frontend-specialist
 description: Frontend development specialist for UI components, React patterns, and user experience
 tools: Read, Edit, Write
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: cyan
 ---

--- a/plugins/psd-coding-system/agents/domain/llm-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/llm-specialist.md
@@ -2,7 +2,7 @@
 name: llm-specialist
 description: LLM integration specialist for AI features, prompt engineering, and multi-provider implementations
 tools: Read, Edit, Write, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: magenta
 ---

--- a/plugins/psd-coding-system/agents/domain/shell-devops-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/shell-devops-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: shell-devops-specialist
 description: Shell scripting semantics, exit codes, JSON parsing, and hook integration specialist
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: cyan
 ---

--- a/plugins/psd-coding-system/agents/domain/ux-specialist.md
+++ b/plugins/psd-coding-system/agents/domain/ux-specialist.md
@@ -2,7 +2,7 @@
 name: ux-specialist
 description: UX heuristic evaluation specialist for interface design, usability assessment, and user experience optimization
 tools: Read, Glob, Grep, WebSearch, Bash
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 ---
 

--- a/plugins/psd-coding-system/agents/external/gemini-3-pro.md
+++ b/plugins/psd-coding-system/agents/external/gemini-3-pro.md
@@ -2,7 +2,7 @@
 name: gemini-3-pro
 description: Advanced AI agent leveraging Google Gemini 3.1 Pro for deep analysis, multimodal reasoning, and complex problem-solving.
 tools: Bash
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 ---
 

--- a/plugins/psd-coding-system/agents/external/gpt-5-codex.md
+++ b/plugins/psd-coding-system/agents/external/gpt-5-codex.md
@@ -2,7 +2,7 @@
 name: gpt-5
 description: Advanced AI agent for second opinions, complex problem solving, and design validation. Leverages GPT-5.3-Codex via codex for deep analysis.
 tools: Bash
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 ---
 

--- a/plugins/psd-coding-system/agents/quality/documentation-writer.md
+++ b/plugins/psd-coding-system/agents/quality/documentation-writer.md
@@ -2,7 +2,7 @@
 name: documentation-writer
 description: Technical documentation specialist for API docs, user guides, and architectural documentation
 tools: Bash, Read, Edit, Write, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: green
 ---

--- a/plugins/psd-coding-system/agents/quality/performance-optimizer.md
+++ b/plugins/psd-coding-system/agents/quality/performance-optimizer.md
@@ -2,7 +2,7 @@
 name: performance-optimizer
 description: Performance optimization specialist for web vitals, database queries, API latency, and system performance
 tools: Bash, Read, Edit, Write, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: purple
 ---

--- a/plugins/psd-coding-system/agents/quality/test-specialist.md
+++ b/plugins/psd-coding-system/agents/quality/test-specialist.md
@@ -2,7 +2,7 @@
 name: test-specialist
 description: Testing specialist for comprehensive test coverage, automation, and quality assurance
 tools: Bash, Read, Edit, Write, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 memory: project
 extended-thinking: true
 keep-coding-instructions: true

--- a/plugins/psd-coding-system/agents/research/best-practices-researcher.md
+++ b/plugins/psd-coding-system/agents/research/best-practices-researcher.md
@@ -2,7 +2,7 @@
 name: best-practices-researcher
 description: Two-phase knowledge lookup (local → online) with mandatory deprecation validation before recommending external APIs or frameworks
 tools: Read, Grep, Glob, WebSearch, WebFetch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 mcpServers:
   - context7

--- a/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
+++ b/plugins/psd-coding-system/agents/research/framework-docs-researcher.md
@@ -2,7 +2,7 @@
 name: framework-docs-researcher
 description: Validates frameworks and APIs are not deprecated, sunset, or EOL before recommending them. Checks official docs, changelogs, and migration guides.
 tools: Read, Grep, Glob, WebSearch, WebFetch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 mcpServers:
   - context7

--- a/plugins/psd-coding-system/agents/research/git-history-analyzer.md
+++ b/plugins/psd-coding-system/agents/research/git-history-analyzer.md
@@ -2,7 +2,7 @@
 name: git-history-analyzer
 description: Git archaeology agent for blame analysis, change velocity, hot file detection, and ownership mapping
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: blue
 ---

--- a/plugins/psd-coding-system/agents/research/learnings-researcher.md
+++ b/plugins/psd-coding-system/agents/research/learnings-researcher.md
@@ -2,7 +2,7 @@
 name: learnings-researcher
 description: Searches knowledge base for relevant past learnings before implementing new features
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 memory: project
 extended-thinking: true
 color: blue

--- a/plugins/psd-coding-system/agents/research/repo-research-analyst.md
+++ b/plugins/psd-coding-system/agents/research/repo-research-analyst.md
@@ -2,7 +2,7 @@
 name: repo-research-analyst
 description: Codebase onboarding and deep research agent for architecture mapping, tech stack identification, and convention discovery
 tools: Read, Grep, Glob, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 mcpServers:
   - context7

--- a/plugins/psd-coding-system/agents/research/spec-flow-analyzer.md
+++ b/plugins/psd-coding-system/agents/research/spec-flow-analyzer.md
@@ -2,7 +2,7 @@
 name: spec-flow-analyzer
 description: Gap analysis for feature specs, user flow permutations, and edge case identification
 tools: Read, Grep, Glob, WebSearch
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: cyan
 ---

--- a/plugins/psd-coding-system/agents/review/adversarial-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/adversarial-reviewer.md
@@ -2,7 +2,7 @@
 name: adversarial-reviewer
 description: Constructs failure scenarios across component boundaries, stress-tests assumptions, and identifies cascading failure modes that escape unit-level reviews
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: orange
 ---

--- a/plugins/psd-coding-system/agents/review/agent-native-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/agent-native-reviewer.md
@@ -2,7 +2,7 @@
 name: agent-native-reviewer
 description: Validates AI-agent architecture parity, prompt consistency, and agent workflow correctness
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: green
 ---
@@ -42,7 +42,7 @@ Validate YAML frontmatter consistency across agents:
 - [ ] `name`: Matches filename (kebab-case)
 - [ ] `description`: Clear, actionable description
 - [ ] `tools`: Valid tool list (Bash, Read, Edit, Write, Grep, Glob, Task, WebSearch, WebFetch)
-- [ ] `model`: Valid model ID (claude-sonnet-4-6, claude-opus-4-8)
+- [ ] `model`: Valid model ID (claude-sonnet-5, claude-opus-4-8)
 - [ ] `extended-thinking`: Boolean (true recommended)
 - [ ] `color`: Valid color for UI display
 
@@ -188,7 +188,7 @@ When invoked by `/work` or `/review-pr`, output:
 | Type | Location | Issue | Fix |
 |------|----------|-------|-----|
 | Missing Reference | skills/work/SKILL.md:45 | `nonexistent-agent` | Remove or create agent |
-| Invalid Model | agents/old-agent.md | `gpt-4` | Use `claude-sonnet-4-6` |
+| Invalid Model | agents/old-agent.md | `gpt-4` | Use `claude-sonnet-5` |
 
 ### Consistency Report
 | Check | Status |

--- a/plugins/psd-coding-system/agents/review/architecture-strategist.md
+++ b/plugins/psd-coding-system/agents/review/architecture-strategist.md
@@ -2,7 +2,7 @@
 name: architecture-strategist
 description: Reviews code for SOLID compliance, anti-pattern detection, and architectural integrity with structured checklists
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: purple
 ---

--- a/plugins/psd-coding-system/agents/review/code-simplicity-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/code-simplicity-reviewer.md
@@ -2,7 +2,7 @@
 name: code-simplicity-reviewer
 description: Enforces YAGNI, flags unnecessary complexity, premature abstractions, and over-engineering. Every line is a liability.
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: green
 ---

--- a/plugins/psd-coding-system/agents/review/correctness-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/correctness-reviewer.md
@@ -2,7 +2,7 @@
 name: correctness-reviewer
 description: Detects logic errors, edge cases, off-by-one bugs, null/undefined handling gaps, and state management issues that escape type checkers and linters
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: cyan
 ---

--- a/plugins/psd-coding-system/agents/review/data-integrity-guardian.md
+++ b/plugins/psd-coding-system/agents/review/data-integrity-guardian.md
@@ -2,7 +2,7 @@
 name: data-integrity-guardian
 description: PII and compliance scanning agent for GDPR, FERPA, and sensitive data handling validation
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: red
 ---

--- a/plugins/psd-coding-system/agents/review/data-migration-expert.md
+++ b/plugins/psd-coding-system/agents/review/data-migration-expert.md
@@ -2,7 +2,7 @@
 name: data-migration-expert
 description: Validates ID mappings, foreign key integrity, and data transformation logic against production reality
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 isolation: worktree
 extended-thinking: true
 color: purple

--- a/plugins/psd-coding-system/agents/review/deployment-verification-agent.md
+++ b/plugins/psd-coding-system/agents/review/deployment-verification-agent.md
@@ -2,7 +2,7 @@
 name: deployment-verification-agent
 description: Go/No-Go checklists for risky deployments (migrations, schema changes, critical paths)
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 isolation: worktree
 extended-thinking: true
 color: orange

--- a/plugins/psd-coding-system/agents/review/pattern-recognition-specialist.md
+++ b/plugins/psd-coding-system/agents/review/pattern-recognition-specialist.md
@@ -2,7 +2,7 @@
 name: pattern-recognition-specialist
 description: Detects code duplication, repeated patterns, and copy-paste violations with systematic threshold-based analysis
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: yellow
 ---

--- a/plugins/psd-coding-system/agents/review/python-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/python-reviewer.md
@@ -2,7 +2,7 @@
 name: python-reviewer
 description: Python code reviewer for type hints, async patterns, security, and Pythonic best practices
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: yellow
 ---

--- a/plugins/psd-coding-system/agents/review/schema-drift-detector.md
+++ b/plugins/psd-coding-system/agents/review/schema-drift-detector.md
@@ -2,7 +2,7 @@
 name: schema-drift-detector
 description: ORM-agnostic schema drift detection comparing model definitions, migrations, and raw SQL schemas
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: orange
 ---

--- a/plugins/psd-coding-system/agents/review/security-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Security specialist for vulnerability analysis, code review, and best-practices validation — returns structured P1/P2/P3 findings (never posts comments)
 tools: Read, Grep, Glob, Bash
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: red
 ---

--- a/plugins/psd-coding-system/agents/review/sql-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/sql-reviewer.md
@@ -2,7 +2,7 @@
 name: sql-reviewer
 description: SQL code reviewer for injection prevention, query performance, schema design, and migration safety
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: cyan
 ---

--- a/plugins/psd-coding-system/agents/review/swift-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/swift-reviewer.md
@@ -2,7 +2,7 @@
 name: swift-reviewer
 description: Swift code reviewer for optionals, memory management, concurrency, and iOS/macOS best practices
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: orange
 ---

--- a/plugins/psd-coding-system/agents/review/typescript-reviewer.md
+++ b/plugins/psd-coding-system/agents/review/typescript-reviewer.md
@@ -2,7 +2,7 @@
 name: typescript-reviewer
 description: TypeScript/JavaScript code reviewer for type safety, async patterns, and framework best practices
 tools: Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: blue
 ---

--- a/plugins/psd-coding-system/agents/validation/breaking-change-validator.md
+++ b/plugins/psd-coding-system/agents/validation/breaking-change-validator.md
@@ -2,7 +2,7 @@
 name: breaking-change-validator
 description: Dependency analysis before deletions to prevent breaking changes
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: red
 ---

--- a/plugins/psd-coding-system/agents/validation/configuration-validator.md
+++ b/plugins/psd-coding-system/agents/validation/configuration-validator.md
@@ -1,7 +1,7 @@
 ---
 name: configuration-validator
 description: Multi-file consistency, version tracking, and configuration drift detection specialist
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: orange
 ---
@@ -66,15 +66,15 @@ When version changes detected, validate ALL 5 required locations are updated:
 **Model Name/ID Consistency:**
 
 When model changes detected, validate consistency across:
-- Agent frontmatter: `model: claude-sonnet-4-6` (current standard)
+- Agent frontmatter: `model: claude-sonnet-5` (current standard — bare alias, no date suffix)
 - Command frontmatter: `model: claude-opus-4-8`
 - Code references: check for hardcoded model names
 - Documentation: ensure model references are up-to-date
 
 **Common model errors:**
-- Inconsistent naming: `claude-sonnet-4-6` vs `sonnet-4-5` vs `claude-sonnet-4-6-20250101`
+- Inconsistent naming: `claude-sonnet-5` vs `sonnet-5` vs `claude-sonnet-5-20260115` (use the bare alias `claude-sonnet-5`)
 - Old model IDs: `claude-opus-4-1` instead of `claude-opus-4-8`
-- Hardcoded in code: `const model = "claude-sonnet-4-6"` instead of config
+- Hardcoded in code: `const model = "claude-sonnet-5"` instead of config
 - Model change in agent but not documented in CLAUDE.md
 
 #### Environment Variable Validation
@@ -295,42 +295,41 @@ grep -h "version.*1\.11\.0" \
 ### High Priority Issue Example
 
 **File:** plugins/psd-coding-system/agents/backend-specialist.md:4
-**Issue:** Outdated model ID - using deprecated claude-sonnet-4-6 instead of current standard
-**Problem:** Agent frontmatter specifies `model: claude-sonnet-4-6` but should use full model ID `claude-sonnet-4-6-20250929` per current convention
-**Impact:** May use wrong model version, inconsistent with other agents
+**Issue:** Stale or date-suffixed model ID instead of the current bare alias
+**Problem:** Agent frontmatter specifies a date-suffixed ID like `model: claude-sonnet-5-20260115` (or a superseded model like `claude-sonnet-4-6`) — the current convention is the **bare alias** `claude-sonnet-5` with **no date suffix** (a date-suffixed Sonnet alias 404s)
+**Impact:** May 404 at launch or pin an unintended snapshot; inconsistent with other agents
 **Inconsistency Evidence:**
 ```bash
 # Check model specifications across all agents
-grep -n "^model:" plugins/psd-coding-system/agents/*.md
+grep -rn "^model:" plugins/psd-coding-system/agents/
 
 # Results show inconsistency:
-backend-specialist.md:4:model: claude-sonnet-4-6  # Incomplete ID
-frontend-specialist.md:4:model: claude-sonnet-4-6-20250929  # Correct
-test-specialist.md:4:model: claude-sonnet-4-6-20250929  # Correct
+backend-specialist.md:model: claude-sonnet-5-20260115  # Wrong — drop the date suffix
+frontend-specialist.md:model: claude-sonnet-5          # Correct — bare alias
+test-specialist.md:model: claude-sonnet-5              # Correct — bare alias
 ```
 **Fix:**
 ```diff
 # plugins/psd-coding-system/agents/backend-specialist.md
 ---
 name: backend-specialist
--model: claude-sonnet-4-6
-+model: claude-sonnet-4-6-20250929
+-model: claude-sonnet-5-20260115
++model: claude-sonnet-5
 extended-thinking: true
 ---
 ```
 **Validation:**
 ```bash
-# All agents should use consistent model ID format
-grep "^model:" plugins/psd-coding-system/agents/*.md | \
-  grep -v "claude-.*-[0-9]\{8\}"
-# Should return empty (no incomplete model IDs)
+# Flag any date-suffixed model IDs — current convention is bare aliases
+grep -rnE "^model:.*-[0-9]{8}$" plugins/psd-coding-system/agents/
+# Should return empty (no date-suffixed model IDs)
 ```
 
 ### Validated Consistency Example
 
 **Validated Consistency:**
 - All 5 version locations in sync at 1.11.0
-- All agent model IDs use full format: `claude-sonnet-4-6-20250929`
+- All agent model IDs use the bare alias: `claude-sonnet-5` (no date suffix)
 - Environment variables: 3 documented in .env.example, 3 used in code (100% match)
 - Agent count: README says "20 agents", actual count: 20 (correct)
 

--- a/plugins/psd-coding-system/agents/validation/document-validator.md
+++ b/plugins/psd-coding-system/agents/validation/document-validator.md
@@ -2,7 +2,7 @@
 name: document-validator
 description: Data validation at extraction boundaries (UTF-8, encoding, database constraints)
 tools: Bash, Read, Edit, Write, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: green
 ---

--- a/plugins/psd-coding-system/agents/validation/telemetry-data-specialist.md
+++ b/plugins/psd-coding-system/agents/validation/telemetry-data-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: telemetry-data-specialist
 description: Data pipeline correctness, metrics accuracy, and statistical validation specialist
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: purple
 ---

--- a/plugins/psd-coding-system/agents/workflow/bug-reproduction-validator.md
+++ b/plugins/psd-coding-system/agents/workflow/bug-reproduction-validator.md
@@ -2,7 +2,7 @@
 name: bug-reproduction-validator
 description: Validates bug reports with documented reproduction attempts, evidence collection, and systematic root cause verification
 tools: Bash, Read, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 color: orange
 ---

--- a/plugins/psd-coding-system/agents/workflow/learning-writer.md
+++ b/plugins/psd-coding-system/agents/workflow/learning-writer.md
@@ -2,7 +2,7 @@
 name: learning-writer
 description: Automatic lightweight learning capture — deduplicates against existing learnings and writes to docs/learnings/
 tools: Bash, Read, Write, Grep, Glob
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 memory: project
 background: true
 keep-coding-instructions: true

--- a/plugins/psd-coding-system/agents/workflow/work-researcher.md
+++ b/plugins/psd-coding-system/agents/workflow/work-researcher.md
@@ -2,7 +2,7 @@
 name: work-researcher
 description: Pre-implementation research orchestrator for /work — dispatches knowledge lookup, codebase research, external validation, git history, and parallel specialist agents
 tools: Bash, Read, Grep, Glob, Task
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 memory: project
 extended-thinking: true
 keep-coding-instructions: true

--- a/plugins/psd-coding-system/agents/workflow/work-validator.md
+++ b/plugins/psd-coding-system/agents/workflow/work-validator.md
@@ -2,7 +2,7 @@
 name: work-validator
 description: Post-implementation validation orchestrator for /work — dispatches language reviewers and deployment verification agents based on changed files
 tools: Bash, Read, Grep, Glob, Task
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 isolation: worktree
 extended-thinking: true
 initialPrompt: "Run post-implementation validation using context from $ARGUMENTS. Detect languages from changed files, dispatch reviewers in LIGHT mode, and return a Validation Report with PASS/PASS_WITH_WARNINGS/FAIL status."

--- a/plugins/psd-productivity/.claude-plugin/plugin.json
+++ b/plugins/psd-productivity/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-productivity",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "36 productivity workflows + 1 agent for Peninsula School District — ParentSquare district data CLI, beautiful HTML artifact generation (incl. self-contained data dashboards & charts), board policy formatting, DocuSign migration/export, PDF Builder, P223 enrollment automation, n8n workflow management, Documenso document signing, Google Workspace CLI, document generation, research, TTS, and district operations",
   "author": {
     "name": "Kris Hagel",

--- a/plugins/psd-productivity/README.md
+++ b/plugins/psd-productivity/README.md
@@ -2,7 +2,7 @@
 
 **36 productivity workflows + 1 agent for Peninsula School District**
 
-Version: 2.15.0
+Version: 2.15.1
 
 Author: Kris Hagel (hagelk@psd401.net)
 

--- a/plugins/psd-productivity/agents/enrollment-validator.md
+++ b/plugins/psd-productivity/agents/enrollment-validator.md
@@ -8,7 +8,7 @@ tools:
   - Grep
   - Write
   - Edit
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 extended-thinking: true
 ---
 


### PR DESCRIPTION
## Summary
Switch all **41 agents** from `claude-sonnet-4-6` → **`claude-sonnet-5`** (40 in psd-coding-system + psd-productivity `enrollment-validator`). Sonnet 5 supports the `effort` parameter (`low`/`medium`/`high`/`xhigh`/`max`), so the old Sonnet 4.6 effort-rejection blocker (GitHub #30795) no longer applies. The 4 heavy agents (`runtime-verifier`, `meta-reviewer`, `architect-specialist`, `plan-validator`) stay on `claude-opus-4-8`.

## Stale-doc fixes (live docs only — historical CHANGELOG left intact)
- **`configuration-validator.md`** — reversed the wrong "append a date suffix (`claude-sonnet-4-6-20250929`)" convention to the current standard: **bare alias `claude-sonnet-5`, no date suffix** (a date-suffixed Sonnet alias 404s). The validation example now flags date-suffixed IDs as the error.
- **`agent-native-reviewer.md`** + **CLAUDE.md** model-selection rules/strategy refreshed to `claude-sonnet-5` (agents default to Sonnet 5; skills still default to `claude-opus-4-8`).

## Versions
- psd-coding-system **3.0.0 → 3.1.0**
- psd-productivity **2.15.0 → 2.15.1**
- marketplace **2.18.0 → 2.19.0**

## Validation
- ✅ `claude plugin validate` clean for both plugins + marketplace
- ✅ version locations consistent; no live `claude-sonnet-4-6` references remain (only historical CHANGELOG)