### PR TITLE
feat(worktree): add /worktree clean post-merge hygiene (restores /clean-branch)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "PSD Plugin Marketplace for Claude Code and Claude Cowork — coding workflows, productivity agents, and district automation",
-    "version": "2.20.0",
+    "version": "2.21.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -15,7 +15,7 @@
       "name": "psd-coding-system",
       "source": "./plugins/psd-coding-system",
       "description": "AI-assisted development system — 3 disciplined surfaces (/plan, /lfg, /evolve), verification-first run-to-100%-clean PR loop, specialized agents, memory-based learning, and Context7 framework docs",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "category": "productivity",
       "keywords": [
         "workflow",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **GitHub label taxonomy** documented per routine and pre-created across all three target repos: `triaged-from-freshservice`; `lfg-ready` / `lfg-in-progress` / `lfg-pr-open` / `lfg-blocked` / `lfg-skip`; `pr-fix-stuck` / `pr-fix-done` / `pr-fix-skip`. Designed for mobile-tap workflows from GitHub's app.
   - **Pattern 1 validation pilot** at `routine-pilots/agent-discovery-check/` (since removed after validation) — confirmed via pilot fires that project-scope `.claude/agents/*.md` AND user-scope `~/.claude/agents/*.md` written by setup are auto-discovered at routine session start, and the env setup script re-runs on every fire with a fresh HOME.
 
+## [2.21.0] - 2026-06-30
+
+### Added
+- **`/worktree clean` — post-merge hygiene** (restores the useful part of the removed `/clean-branch`). One command sweeps: stale worktrees (both `.worktrees/*` and the auto `.claude/worktrees/*`), merged local branches, lingering remote branches whose PR merged/closed, and issues still open whose PR already merged. **Squash-merge-aware** — detects merged branches via `gh pr list --head <branch> --state merged`, not just `git branch --merged` (which misses squash merges, the default for this org). Excludes `main`/`dev`/`master`, `dependabot/*`, and any branch with an open PR; **confirms** the destructive remote-branch deletions and issue closes via AskUserQuestion before running. Documents the auto-close gotcha (GitHub only auto-closes an issue when its PR merges into the repo's *default* branch). The lightweight worktrees-only sweep is split out as its own `/worktree prune` subcommand.
+
+### Changed
+- Versions: **psd-coding-system 3.2.0 → 3.3.0**, **marketplace 2.20.0 → 2.21.0**. Updated `worktrees-explained.md`, `how-to-use.md`, the plugin README, and the CLAUDE.md skill table for the new `clean` subcommand.
+
 ## [2.20.0] - 2026-06-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the **PSD Plugin Marketplace** — a multi-plugin marketplace for Claude Code and Claude Cowork, maintained by Peninsula School District.
 
-**Version**: 2.20.0
+**Version**: 2.21.0
 **Status**: Production-Ready
 
 ### Plugins
@@ -131,7 +131,7 @@ psd-claude-plugins/                           # repo root
 | `/lfg` | Autonomous build-to-done: implement → verify the full DoD (build/lint-zero-warning/typecheck/**full** suite/Playwright + screenshots) → open PR with visual evidence → watch CI + the project's AI reviewers and fix every round until **100% clean**. Absorbs work/test/debug/optimize/review-pr/security-audit |
 | `/evolve` | Compound learnings into CLAUDE.md/patterns/agents then **prune** them; release tracking; competitor compare |
 | `/setup` | Write `.psd/verify.json` — the per-project verification gate (commands, E2E flows, strictness, AI-reviewer logins, commit-learnings, active review agents) |
-| `/worktree` | Git worktree management + the multi-window "run several `/lfg` in parallel" how-to |
+| `/worktree` | Git worktree management + multi-window parallel how-to + `clean` post-merge hygiene (prune worktrees, delete merged local/remote branches, close orphaned issues — restores `/clean-branch`) |
 | `/bump-version` | Version bump ritual (absorbs `/changelog`) — three independent tracks |
 
 **Removed/folded in v3.0.0:** work, test, debug, optimize, review-pr, security-audit, architect, brainstorm, scope, product-manager, deepen-plan, issue, changelog, clean-branch, swarm, triage (triage intake now lives only in the cloud routine). Contracts: `docs/patterns/{definition-of-done,issue-contract,worktrees-explained}.md`.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Peninsula School District's plugin marketplace for Claude Code and Claude Cowork
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blue)](https://docs.claude.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/Version-2.20.0-green)]()
+[![Version](https://img.shields.io/badge/Version-2.21.0-green)]()
 
 ## Overview
 
 **Two independently installable plugins** — one for software development workflows, one for general productivity.
 
-**Version**: 2.20.0
+**Version**: 2.21.0
 
 ---
 

--- a/plugins/psd-coding-system/.claude-plugin/plugin.json
+++ b/plugins/psd-coding-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/plugin.schema.json",
   "name": "psd-coding-system",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "AI-assisted development system for Peninsula School District - workflow automation, specialized agents, memory-based learning, and Context7 framework docs",
   "author": {
     "name": "Kris Hagel",

--- a/plugins/psd-coding-system/README.md
+++ b/plugins/psd-coding-system/README.md
@@ -2,7 +2,7 @@
 
 **Comprehensive AI-assisted development system for Peninsula School District**
 
-Version: 3.2.0
+Version: 3.3.0
 Status: Production-Ready Workflows + Memory-Based Learning
 Author: Kris Hagel (hagelk@psd401.net)
 
@@ -54,7 +54,7 @@ Six skills, each with a clear lane. The old 21 skills were absorbed — `/plan` 
 | `/lfg` | Autonomous build-to-done: implement → verify-loop (build, zero-warning lint, typecheck, full test suite, Playwright E2E + screenshots) until green → open a PR with embedded screenshots → watch CI + the project's AI reviewers and fix every round until APPROVED and all checks pass. Commits learnings. Absorbs work, test, debug, optimize, review-pr, security-audit. | `/lfg 347` or `/lfg "fix login redirect"` |
 | `/evolve` | Compound learnings into CLAUDE.md / patterns / agents then prune them; release tracking; competitor compare. | `/evolve` |
 | `/setup` | Write `.psd/verify.json` — the per-project verify gate (commands, E2E flows, strictness, AI-reviewer logins, commit_learnings, active review agents). | `/setup` / `/setup show` / `/setup reset` |
-| `/worktree` | Git worktree management + a multi-window "run several `/lfg` in parallel" how-to. | `/worktree 347` or `/worktree list` |
+| `/worktree` | Git worktree management + multi-window parallel how-to + `/worktree clean` post-merge hygiene (prune worktrees, delete merged local/remote branches, close orphaned issues). | `/worktree 347` · `/worktree clean` |
 | `/bump-version` | The version-bump ritual across three independent tracks (absorbs `/changelog`). | `/bump-version minor` |
 
 > **Removed in v3.0.0:** `/work`, `/test`, `/debug`, `/optimize`, `/review-pr`, `/security-audit`, `/architect`, `/brainstorm`, `/scope`, `/product-manager`, `/deepen-plan`, `/issue`, `/changelog`, `/clean-branch`, `/swarm`, `/triage`. Their behavior is folded into the six skills above. (FreshService-ticket intake now lives only in the cloud `triage` routine, not as a local skill.)

--- a/plugins/psd-coding-system/docs/how-to-use.md
+++ b/plugins/psd-coding-system/docs/how-to-use.md
@@ -96,3 +96,4 @@ They never merge PRs and never edit protected files (`.claude/`, hooks, workflow
 | Work on several issues at once | `/worktree` + a Claude window each |
 | Bank learnings / improve the plugin | `/evolve` |
 | Cut a release | `/bump-version` |
+| Tidy up after merges — delete merged branches (local + remote), prune worktrees, close orphaned issues | `/worktree clean` |

--- a/plugins/psd-coding-system/docs/patterns/worktrees-explained.md
+++ b/plugins/psd-coding-system/docs/patterns/worktrees-explained.md
@@ -73,5 +73,5 @@ Under the hood `/lfg` uses Claude Code's built-in worktree support (`EnterWorktr
 
 - **Don't check out the same branch in two worktrees** — git refuses; each branch lives in exactly one worktree.
 - **Worktrees are folders on disk** — they take space and have their own `node_modules`. Run install once per worktree (or symlink/hardlink heavy dirs if your tooling supports it).
-- **Clean up after merge** — a stale worktree pointing at a deleted branch is clutter; `/worktree clean` prunes them.
+- **Clean up after merge** — `/worktree clean` is full post-merge hygiene: it prunes stale worktrees, deletes merged local **and** remote branches (squash-merge-aware), and closes issues whose PR already merged (confirming the destructive steps first). `/worktree prune` is the lightweight worktrees-only version.
 - **`.env` and secrets** — the `WorktreeCreate` hook symlinks `.env`; anything else machine-specific you need, copy in.

--- a/plugins/psd-coding-system/skills/worktree/SKILL.md
+++ b/plugins/psd-coding-system/skills/worktree/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktree
-description: Parallel development using git worktrees — work on multiple branches simultaneously
-argument-hint: "[branch-name or issue-number] [optional: base-branch]"
+description: Parallel development with git worktrees — create/list/remove worktrees, plus `clean` for post-merge hygiene (prune worktrees, delete merged local+remote branches, close orphaned issues)
+argument-hint: "[issue-number | branch-name | list | clean | prune | remove <branch>]"
 model: claude-opus-4-8
 effort: high
 context: fork
@@ -11,6 +11,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - AskUserQuestion
 extended-thinking: true
 ---
 
@@ -30,7 +31,10 @@ case "$ARGS" in
   list|ls)
     SUBCOMMAND="list"
     ;;
-  clean|prune)
+  prune)
+    SUBCOMMAND="prune"
+    ;;
+  clean|sweep|tidy)
     SUBCOMMAND="clean"
     ;;
   remove\ *|rm\ *)
@@ -60,7 +64,7 @@ echo "=== Branches in Worktrees ==="
 git worktree list --porcelain | grep "^branch" | sed 's/branch refs\/heads\//  /'
 ```
 
-### If `clean`:
+### If `prune` (worktrees only — lightweight):
 
 ```bash
 echo "=== Pruning stale worktrees ==="
@@ -70,6 +74,65 @@ echo ""
 echo "=== Remaining worktrees ==="
 git worktree list
 ```
+
+### If `clean` (post-merge hygiene — restores what `/clean-branch` used to do):
+
+Sweeps merged branches (local **and** remote, squash-merge-aware), stale worktrees, and issues that should be closed. Gather the candidates first; the destructive steps (remote-branch deletion, issue closing) are confirmed before running.
+
+```bash
+echo "=== /worktree clean — post-merge hygiene ==="
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main)
+if git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then BASE=dev; else BASE="$DEFAULT_BRANCH"; fi
+CUR=$(git branch --show-current); PROT='^(main|master|dev|HEAD)$'
+
+git fetch --prune origin --quiet 2>/dev/null || true   # drop tracking refs for branches already deleted on the remote
+
+echo "--- 1. local branches whose work is merged (safe to delete) ---"
+LOCAL_DELETE=""
+for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+  echo "$b" | grep -qE "$PROT" && continue
+  [ "$b" = "$CUR" ] && continue
+  # normal-merged into base, OR its PR is merged (covers squash merges, which change the SHA)
+  if git merge-base --is-ancestor "$b" "origin/$BASE" 2>/dev/null \
+     || [ -n "$(gh pr list --head "$b" --state merged --limit 1 --json number --jq '.[].number' 2>/dev/null)" ]; then
+    LOCAL_DELETE="$LOCAL_DELETE $b"
+  fi
+done
+echo "${LOCAL_DELETE:-(none)}"
+
+echo "--- 2. worktrees (remove any on a merged/gone branch) ---"
+git worktree list
+
+echo "--- 3. remote branches whose PR is MERGED/CLOSED (dependabot excluded) ---"
+REMOTE_DELETE=""
+for rb in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | sed 's#^origin/##'); do
+  echo "$rb" | grep -qE "$PROT" && continue
+  echo "$rb" | grep -qE '^dependabot/' && continue     # Dependabot manages its own branches
+  S=$(gh pr list --head "$rb" --state all --limit 1 --json state --jq '.[].state' 2>/dev/null)
+  case "$S" in MERGED|CLOSED) REMOTE_DELETE="$REMOTE_DELETE $rb" ;; esac
+done
+echo "${REMOTE_DELETE:-(none)}"
+
+echo "--- 4. issues still OPEN whose linked PR already merged ---"
+ORPHANS=""
+for pr in $(gh pr list --state merged --limit 30 --json number --jq '.[].number' 2>/dev/null); do
+  for issue in $(gh pr view "$pr" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null); do
+    [ "$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null)" = "OPEN" ] && ORPHANS="$ORPHANS #${issue}(PR#${pr})"
+  done
+done
+echo "${ORPHANS:-(none)}"
+```
+
+Then act on the candidates:
+
+1. **Local branches** — delete the merged ones (they're already merged, so this is non-destructive): `git branch -D <branch>` for each in list 1.
+2. **Worktrees** — `git worktree prune`; for any worktree whose branch is in list 1 (merged) or gone, `git worktree remove <path>` (confirm no uncommitted changes first; `git worktree list` shows paths). Both `.worktrees/*` (manual) and `.claude/worktrees/*` (auto from `/lfg`) are covered.
+3. **Remote branches** (list 3) — remote deletion is destructive and outward-facing. **Use AskUserQuestion to confirm the list first**, then `git push origin --delete <branch>` for each approved branch.
+4. **Orphan issues** (list 4) plus any merged PR that had **no** closing reference but an issue number in its head branch (`feature/<N>-…`, `claude/lfg-issue-<N>-…`) — surface those as *candidates*, and verify each really is the work that PR did (check the issue title) before acting. **Confirm with AskUserQuestion**, then `gh issue close <N> --comment "Closed via merged PR #<pr>."` for each approved one.
+
+Print a summary: local branches deleted, remote branches deleted, worktrees removed, issues closed.
+
+> **Note on auto-close:** issues only auto-close when their PR merges into the repo's **default** branch. If a repo's default is `main` but PRs target `dev`, `Closes #N` won't fire until `dev` → `main` — step 4 closes them explicitly so they don't linger.
 
 ### If `remove`:
 
@@ -161,7 +224,7 @@ Present the result clearly:
 - **Path:** [worktree path]
 - **Branch:** [branch name]
 - **Base:** [base branch]
-- **Status:** [created / listed / removed / pruned]
+- **Status:** [created / listed / removed / pruned / cleaned]
 
 **Tip:** Each worktree is a full, independent checkout. Open a separate Claude Code window in it and run `/lfg` — multiple worktrees = multiple `/lfg` sessions in parallel, with zero collisions. New to worktrees? Read `docs/patterns/worktrees-explained.md`.
 ```


### PR DESCRIPTION
## Summary
Restores the post-merge cleanup that `/clean-branch` used to do, folded into `/worktree` as a new **`clean`** subcommand (keeps the skill count flat). Shipped as **2.21.0**.

`/worktree clean` sweeps, in one command:
- **Stale worktrees** — both `.worktrees/*` (manual) and `.claude/worktrees/*` (auto from `/lfg`).
- **Merged local branches** — **squash-merge-aware** (`gh pr list --head <b> --state merged`), so it catches squash merges that `git branch --merged` misses.
- **Lingering remote branches** whose PR is merged/closed.
- **Orphan issues** — still-open issues whose linked PR already merged (covers PRs that forgot `Closes #N`, and the dev-vs-default-branch auto-close gotcha).

Safety: excludes `main`/`dev`/`master`, `dependabot/*`, and any branch with an open PR; **confirms remote-branch deletion and issue closing via AskUserQuestion** before doing anything destructive/outward-facing. The lightweight worktrees-only sweep is now `/worktree prune`.

## Why
The v3.0.0 overhaul dropped `/clean-branch` and left branch/worktree/issue cleanup without a home — verified live: aistudio had lingering `claude/lfg-issue-970-*`, `add-people-api-scope`, etc., and at least one merged PR that didn't link its issue.

## Validation
- ✅ `claude plugin validate` clean (plugin + marketplace); versions consistent (coding 3.3.0 / marketplace 2.21.0)
- ✅ subcommand `case` block parses (`bash -n`)