### PR TITLE
Migrate to org reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,5 +6,10 @@ jobs:
   claude-review:
     # Dependabot cannot grant id-token: write to the reusable (startup_failure).
     if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
     uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main
     secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,44 +1,8 @@
-name: Claude Code Review
-
+name: Claude Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-
+    types: [opened, ready_for_review, reopened]
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+    uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main
+    secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,5 +4,7 @@ on:
     types: [opened, ready_for_review, reopened]
 jobs:
   claude-review:
+    # Dependabot cannot grant id-token: write to the reusable (startup_failure).
+    if: github.actor != 'dependabot[bot]'
     uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main
     secrets: inherit


### PR DESCRIPTION
## What changed

- `.github/workflows/claude-code-review.yml` now calls the organization reusable workflow at `PSD401/.github/.github/workflows/reusable-claude-review.yml@main` with `secrets: inherit`.
- The caller retains the previous least-privilege token contract: `contents: read`, `pull-requests: read`, `issues: read`, and `id-token: write`.
- `.github/dependabot.yml` adds weekly update checks for GitHub Actions references used in this repository.

The reusable workflow centralizes checkout, pinned action versions, authentication fallback, review instructions, timeout, and concurrency policy.

## Intentional behavior changes

1. **Review trigger set:** `[opened, synchronize, ready_for_review, reopened]` becomes `[opened, ready_for_review, reopened]`. Removing `synchronize` is the organization cost-control standard; a new review can still be requested with `@claude review`.
2. **Draft PRs:** the reusable workflow skips draft pull requests and runs when they become ready for review.
3. **Dependabot PRs:** the caller explicitly skips Dependabot because Dependabot-triggered callers cannot grant `id-token: write`; this is the permitted skipped-review case.
4. **Reviewer implementation:** the repository-specific plugin prompt is replaced by the organization-standard reusable reviewer and its centralized authentication/model/prompt policy.

No test or lint step is deleted, deselected, or disabled.

## VERIFICATION EVIDENCE

All commands below were run against final diff commit `8802619`.

### Workflow lint

Pinned release binary:

```text
$ actionlint -version
1.7.7
$ actionlint .github/workflows/claude-code-review.yml
# exit 0; no findings
```

### YAML parsing

Using Python in a temporary virtual environment with PyYAML 6.0.2:

```text
$ python -c 'import yaml,sys; [yaml.safe_load(open(path)) for path in sys.argv[1:]]; print(f"validated {len(sys.argv)-1} YAML files")' .github/workflows/claude-code-review.yml .github/dependabot.yml
validated 2 YAML files
```

### Patch integrity

```text
$ git diff --check origin/main...HEAD
# exit 0; no findings
```

### GitHub Actions

- [`Claude Review` run 31858556273](https://github.com/psd401/psd-claude-plugins/actions/runs/31858556273), triggered by `ready_for_review` on `8802619`: **pass**. The reusable caller resolved and all job setup/teardown steps completed, eliminating the prior `startup_failure`. The action emitted its expected safety annotation that review execution is skipped while the review workflow differs from the default branch; this restriction clears when the validated caller is merged.
- [CodeQL run 31858510156](https://github.com/psd401/psd-claude-plugins/actions/runs/31858510156): **pass** for Actions, Go, JavaScript/TypeScript, and Python.
- Final CodeQL summary: **No new alerts in code changed by this pull request**; the previous missing-permissions instance is fixed.

---
Part of the Phase 3 standard-CI rollout. Human review and merge required.
